### PR TITLE
climb time change

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -2,9 +2,9 @@
 	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY // Detach for turfs
 	argument_hash_start_idx = 2
 	///Time it takes to climb onto the object
-	var/climb_time = (2 SECONDS)
+	var/climb_time = (0.35 SECONDS)
 	///Stun duration for when you get onto the object
-	var/climb_stun = (2 SECONDS)
+	var/climb_stun = (0.25 SECONDS)
 	///Assoc list of object being climbed on - climbers.  This allows us to check who needs to be shoved off a climbable object when its clicked on.
 	var/list/current_climbers
 
@@ -61,8 +61,8 @@
 								span_notice("You start climbing onto [climbed_thing]..."))
 	var/adjusted_climb_time = climb_time
 	var/adjusted_climb_stun = climb_stun
-	if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) //climbing takes twice as long without help from the hands.
-		adjusted_climb_time *= 2
+	/*if(HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)) //climbing takes twice as long without help from the hands.
+		adjusted_climb_time *= 2 */ // why?
 	if(isalien(user))
 		adjusted_climb_time *= 0.25 //aliens are terrifyingly fast
 	if(HAS_TRAIT(user, TRAIT_FREERUNNING)) //do you have any idea how fast I am???


### PR DESCRIPTION
## About The Pull Request
Makes climbing tables, railings and anything similar much faster.
climb_time = 0.35 seconds (from 2 seconds)
climb_stun = 0.25 seconds (from 2)

Also comments out a part of the code that makes climbing take longer if your hands are full.
## Why It's Good For The Game
smoother interactions
## Changelog
:cl:
del: climbing speed is no longer effected by what you're holding
balance: climbing is faster
/:cl:
