### PR TITLE
free vendors + lathe tax removal

### DIFF
--- a/code/__DEFINES/economy.dm
+++ b/code/__DEFINES/economy.dm
@@ -16,9 +16,9 @@
 #define PAYCHECK_COMMAND 100
 
 //How many credits a player is charged if they print something from a departmental lathe they shouldn't have access to.
-#define LATHE_TAX 10
+#define LATHE_TAX 0
 //How much POWER a borg's cell is taxed if they print something from a departmental lathe.
-#define SILICON_LATHE_TAX 2000
+#define SILICON_LATHE_TAX 0
 
 #define STATION_TARGET_BUFFER 25
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -227,7 +227,7 @@ RLD
 	worn_icon_state = "RCD"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	custom_premium_price = PAYCHECK_COMMAND * 10
+	//custom_premium_price = PAYCHECK_COMMAND * 10
 	max_matter = 160
 	slot_flags = ITEM_SLOT_BELT
 	item_flags = NO_MAT_REDEMPTION | NOBLUDGEON

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -691,7 +691,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	heat = 1500
 	resistance_flags = FIRE_PROOF
 	grind_results = list(/datum/reagent/iron = 1, /datum/reagent/fuel = 5, /datum/reagent/fuel/oil = 5)
-	custom_price = PAYCHECK_CREW * 1.1
+	//custom_price = PAYCHECK_CREW * 1.1
 	light_system = MOVABLE_LIGHT
 	light_range = 2
 	light_power = 0.6

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -520,7 +520,7 @@
 /obj/item/circuitboard/machine/vendor
 	name = "Custom Vendor"
 	desc = "You can turn the \"brand selection\" dial using a screwdriver."
-	custom_premium_price = PAYCHECK_CREW * 1.5
+	//custom_premium_price = PAYCHECK_CREW * 1.5
 	build_path = /obj/machinery/vending/custom
 	req_components = list(/obj/item/vending_refill/custom = 1)
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -612,7 +612,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	desc = "A metallic container containing tasty paint."
 	w_class = WEIGHT_CLASS_SMALL
-	custom_price = PAYCHECK_CREW * 2.5
+	//custom_price = PAYCHECK_CREW * 2.5
 
 	instant = TRUE
 	edible = FALSE

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -1,7 +1,7 @@
 /obj/item/flashlight
 	name = "flashlight"
 	desc = "A hand-held emergency light."
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	icon = 'icons/obj/lighting.dmi'
 	icon_state = "flashlight"
 	inhand_icon_state = "flashlight"
@@ -462,7 +462,7 @@
 /obj/item/flashlight/glowstick
 	name = "glowstick"
 	desc = "A military-grade glowstick."
-	custom_price = PAYCHECK_LOWER
+	//custom_price = PAYCHECK_LOWER
 	w_class = WEIGHT_CLASS_SMALL
 	light_range = 4
 	light_system = MOVABLE_LIGHT

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -27,7 +27,7 @@
 	drop_sound = 'sound/items/handling/multitool_drop.ogg'
 	pickup_sound = 'sound/items/handling/multitool_pickup.ogg'
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=20)
-	custom_premium_price = PAYCHECK_COMMAND * 3
+	//custom_premium_price = PAYCHECK_COMMAND * 3
 	toolspeed = 1
 	usesound = 'sound/weapons/empty.ogg'
 	var/obj/machinery/buffer // simple machine buffer for device linkage

--- a/code/game/objects/items/devices/portable_chem_mixer.dm
+++ b/code/game/objects/items/devices/portable_chem_mixer.dm
@@ -7,8 +7,8 @@
 	w_class = WEIGHT_CLASS_HUGE
 	slot_flags = ITEM_SLOT_BELT
 	equip_sound = 'sound/items/equip/toolbelt_equip.ogg'
-	custom_price = PAYCHECK_CREW * 10
-	custom_premium_price = PAYCHECK_CREW * 14
+	//custom_price = PAYCHECK_CREW * 10
+	//custom_premium_price = PAYCHECK_CREW * 14
 
 	var/obj/item/reagent_containers/beaker = null ///Creating an empty slot for a beaker that can be added to dispense into
 	var/amount = 30 ///The amount of reagent that is to be dispensed currently

--- a/code/game/objects/items/devices/scanners/gas_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/gas_analyzer.dm
@@ -1,7 +1,7 @@
 /obj/item/analyzer
 	desc = "A hand-held environmental scanner which reports current gas levels."
 	name = "gas analyzer"
-	custom_price = PAYCHECK_LOWER * 0.9
+	//custom_price = PAYCHECK_LOWER * 0.9
 	icon = 'icons/obj/device.dmi'
 	icon_state = "analyzer"
 	inhand_icon_state = "analyzer"

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -25,7 +25,7 @@
 	var/mode = SCANNER_VERBOSE
 	var/scanmode = SCANMODE_HEALTH
 	var/advanced = FALSE
-	custom_price = PAYCHECK_COMMAND
+	//custom_price = PAYCHECK_COMMAND
 
 /obj/item/healthanalyzer/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/devices/scanners/t_scanner.dm
+++ b/code/game/objects/items/devices/scanners/t_scanner.dm
@@ -1,7 +1,7 @@
 /obj/item/t_scanner
 	name = "\improper T-ray scanner"
 	desc = "A terahertz-ray emitter and scanner used to detect underfloor objects such as cables and pipes."
-	custom_price = PAYCHECK_LOWER * 0.7
+	//custom_price = PAYCHECK_LOWER * 0.7
 	icon = 'icons/obj/device.dmi'
 	icon_state = "t-ray0"
 	var/on = FALSE

--- a/code/game/objects/items/devices/sensor_device.dm
+++ b/code/game/objects/items/devices/sensor_device.dm
@@ -9,8 +9,8 @@
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_SMALL
 	slot_flags = ITEM_SLOT_BELT
-	custom_price = PAYCHECK_CREW * 5
-	custom_premium_price = PAYCHECK_CREW * 6
+	//custom_price = PAYCHECK_CREW * 5
+	//custom_premium_price = PAYCHECK_CREW * 6
 
 /obj/item/sensor_device/attack_self(mob/user)
 	GLOB.crewmonitor.show(user,src) //Proc already exists, just had to call it

--- a/code/game/objects/items/food/burgers.dm
+++ b/code/game/objects/items/food/burgers.dm
@@ -14,7 +14,7 @@
 	desc = "The cornerstone of every nutritious breakfast."
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 1)
 	foodtypes = GRAIN | MEAT
-	custom_price = PAYCHECK_CREW * 0.8
+	//custom_price = PAYCHECK_CREW * 0.8
 	venue_value = FOOD_PRICE_CHEAP
 
 /obj/item/food/burger/plain/Initialize(mapload)
@@ -332,7 +332,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 5, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("bun" = 2, "a home run" = 4)
 	foodtypes = GRAIN | GROSS
-	custom_price = PAYCHECK_CREW * 0.8
+	//custom_price = PAYCHECK_CREW * 0.8
 	venue_value = FOOD_PRICE_NORMAL
 
 /obj/item/food/burger/baconburger
@@ -342,7 +342,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 6, /datum/reagent/consumable/nutriment/vitamin = 2)
 	tastes = list("bacon" = 4, "bun" = 2)
 	foodtypes = GRAIN | MEAT
-	custom_premium_price = PAYCHECK_CREW * 1.6
+	//custom_premium_price = PAYCHECK_CREW * 1.6
 	venue_value = FOOD_PRICE_NORMAL
 
 /obj/item/food/burger/empoweredburger

--- a/code/game/objects/items/food/moth.dm
+++ b/code/game/objects/items/food/moth.dm
@@ -760,7 +760,7 @@
 	name = "\improper Activin 12 Hour medicated gum packet"
 	desc = "Stay awake during long shifts in the maintenance tunnels with Activin! The approval seal of the Mothic Nomad Fleet is emblazoned on the packaging, alongside a litany of health and safety disclaimers in both Mothic and Galactic Common."
 	icon_state = "bubblegum_wake_up"
-	custom_premium_price = PAYCHECK_CREW * 1.5
+	//custom_premium_price = PAYCHECK_CREW * 1.5
 
 /obj/item/storage/box/gum/wake_up/examine_more(mob/user)
 	. = ..()

--- a/code/game/objects/items/food/salad.dm
+++ b/code/game/objects/items/food/salad.dm
@@ -137,7 +137,7 @@
 	reagent_flags = OPENCONTAINER
 	custom_materials = list(/datum/material/glass = 500)
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_price = PAYCHECK_CREW * 0.6
+	//custom_price = PAYCHECK_CREW * 0.6
 
 /obj/item/reagent_containers/cup/bowl/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -25,7 +25,7 @@
 	bite_consumption = 10
 	tastes = list("candy" = 5, "weight loss" = 4, "insect larva" = 1)
 	foodtypes = JUNKFOOD | RAW | BUGS
-	custom_price = 80
+	//custom_price = 80
 	w_class = WEIGHT_CLASS_TINY
 	var/revelation = FALSE
 
@@ -101,7 +101,7 @@
 	tastes = list("dried raisins" = 1)
 	foodtypes = JUNKFOOD | FRUIT | SUGAR
 	food_flags = FOOD_FINGER_FOOD
-	custom_price = PAYCHECK_CREW * 0.7
+	//custom_price = PAYCHECK_CREW * 0.7
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/no_raisin/healthy
@@ -120,7 +120,7 @@
 	junkiness = 25
 	foodtypes = JUNKFOOD | GRAIN | SUGAR
 	food_flags = FOOD_FINGER_FOOD
-	custom_price = PAYCHECK_LOWER
+	//custom_price = PAYCHECK_LOWER
 	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/food/candy_trash
@@ -178,7 +178,7 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2)
 	tastes = list("peanuts" = 4, "anger" = 1)
 	foodtypes = JUNKFOOD | NUTS
-	custom_price = PAYCHECK_CREW * 0.8 //nuts are expensive in real life, and this is the best food in the vendor.
+	//custom_price = PAYCHECK_CREW * 0.8 //nuts are expensive in real life, and this is the best food in the vendor.
 	junkiness = 10 //less junky than other options, since peanuts are a decently healthy snack option
 	w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/cooking_oil = 2)
@@ -310,7 +310,7 @@ GLOBAL_LIST_INIT(safe_peanut_types, populate_safe_peanut_types())
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/nutriment/vitamin = 1) //a healthy but expensive snack
 	tastes = list("pistachios" = 4, "subtle sweetness" = 1)
 	foodtypes = JUNKFOOD | NUTS
-	custom_price = PAYCHECK_CREW//pistachios are even more expensive.
+	//custom_price = PAYCHECK_CREW//pistachios are even more expensive.
 	junkiness = 10 //on par with peanuts
 	w_class = WEIGHT_CLASS_SMALL
 	grind_results = list(/datum/reagent/consumable/peanut_butter = 5, /datum/reagent/consumable/cooking_oil = 2)
@@ -323,7 +323,7 @@ GLOBAL_LIST_INIT(safe_peanut_types, populate_safe_peanut_types())
 	food_reagents = list(/datum/reagent/consumable/cornoil  = 1, /datum/reagent/consumable/salt = 6) //1 cornoil is equal to 1.33 nutriment
 	tastes = list("sunflowers" = 5)
 	foodtypes = JUNKFOOD | NUTS
-	custom_price = PAYCHECK_LOWER * 0.4 //sunflowers are cheap in real life.
+	//custom_price = PAYCHECK_LOWER * 0.4 //sunflowers are cheap in real life.
 	bite_consumption = 1
 	junkiness = 25
 	w_class = WEIGHT_CLASS_SMALL
@@ -345,7 +345,7 @@ GLOBAL_LIST_INIT(safe_peanut_types, populate_safe_peanut_types())
 	bite_consumption = 2
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/cooking_oil = 2, /datum/reagent/consumable/salt = 3)
 	junkiness = 20
-	custom_price = PAYCHECK_LOWER * 0.8  //we are filled to the brim with flavor
+	//custom_price = PAYCHECK_LOWER * 0.8  //we are filled to the brim with flavor
 	tastes = list("fried corn" = 1)
 	foodtypes = JUNKFOOD | FRIED
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -53,7 +53,7 @@
 	var/flashbang_range = 1 //how many tiles away the mob will be stunned.
 	shrapnel_type = /obj/projectile/bullet/pellet/stingball
 	shrapnel_radius = 5
-	custom_premium_price = PAYCHECK_COMMAND * 3.5 // mostly gotten through cargo, but throw in one for the sec vendor ;)
+	//custom_premium_price = PAYCHECK_COMMAND * 3.5 // mostly gotten through cargo, but throw in one for the sec vendor ;)
 
 /obj/item/grenade/stingbang/mega
 	name = "mega stingbang"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -41,7 +41,7 @@
 	custom_materials = list(/datum/material/iron=500)
 	breakouttime = 1 MINUTES
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 50)
-	custom_price = PAYCHECK_COMMAND * 0.35
+	//custom_price = PAYCHECK_COMMAND * 0.35
 	///Sound that plays when starting to put handcuffs on someone
 	var/cuffsound = 'sound/weapons/handcuffs.ogg'
 	///If set, handcuffs will be destroyed on application and leave behind whatever this is set to.
@@ -551,7 +551,7 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	w_class = WEIGHT_CLASS_SMALL
 	breakouttime = 1.5 SECONDS
-	custom_price = PAYCHECK_COMMAND * 0.35
+	//custom_price = PAYCHECK_COMMAND * 0.35
 
 /obj/item/restraints/legcuffs/bola/energy/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -34,7 +34,7 @@
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 30)
 	sharpness = SHARP_POINTY
 	var/datum/reagent/forkload //used to eat omelette
-	custom_price = PAYCHECK_LOWER
+	//custom_price = PAYCHECK_LOWER
 
 /obj/item/kitchen/fork/Initialize(mapload)
 	. = ..()
@@ -69,7 +69,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 0
 	custom_materials = list(/datum/material/plastic=80)
-	custom_price = PAYCHECK_LOWER * 2
+	//custom_price = PAYCHECK_LOWER * 2
 
 /obj/item/kitchen/fork/plastic/Initialize(mapload)
 	. = ..()
@@ -92,7 +92,7 @@
 	attack_verb_continuous = list("prods", "whiffs", "scratches", "pokes")
 	attack_verb_simple = list("prod", "whiff", "scratch", "poke")
 	sharpness = SHARP_EDGED
-	custom_price = PAYCHECK_LOWER * 2
+	//custom_price = PAYCHECK_LOWER * 2
 
 /obj/item/knife/plastic/Initialize(mapload)
 	. = ..()
@@ -112,7 +112,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("bashes", "batters", "bludgeons", "thrashes", "whacks")
 	attack_verb_simple = list("bash", "batter", "bludgeon", "thrash", "whack")
-	custom_price = PAYCHECK_CREW * 1.5
+	//custom_price = PAYCHECK_CREW * 1.5
 	tool_behaviour = TOOL_ROLLINGPIN
 
 /obj/item/kitchen/rollingpin/illegal
@@ -123,7 +123,7 @@
 	force = 12
 	flags_1 = CONDUCT_1
 	custom_materials = list(/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 1.5, /datum/material/plastic = MINERAL_MATERIAL_AMOUNT * 1.5)
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2
 	bare_wound_bonus = 14
 
 /obj/item/kitchen/rollingpin/suicide_act(mob/living/carbon/user)
@@ -144,7 +144,7 @@
 	attack_verb_continuous = list("whacks", "spoons", "taps")
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 30)
 	custom_materials = list(/datum/material/iron=120)
-	custom_price = PAYCHECK_LOWER * 5
+	//custom_price = PAYCHECK_LOWER * 5
 	tool_behaviour = TOOL_MINING
 	toolspeed = 25 // Literally 25 times worse than the base pickaxe
 
@@ -153,7 +153,7 @@
 	icon_state = "plastic_spoon"
 	force = 0
 	custom_materials = list(/datum/material/plastic=120)
-	custom_price = PAYCHECK_LOWER * 2
+	//custom_price = PAYCHECK_LOWER * 2
 	toolspeed = 75 // The plastic spoon takes 5 minutes to dig through a single mineral turf... It's one, continuous, breakable, do_after...
 
 /obj/item/kitchen/spoon/plastic/Initialize(mapload)

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -94,7 +94,7 @@
 	attack_verb_continuous = list("slices", "dices", "chops", "cubes", "minces", "juliennes", "chiffonades", "batonnets")
 	attack_verb_simple = list("slice", "dice", "chop", "cube", "mince", "julienne", "chiffonade", "batonnet")
 	w_class = WEIGHT_CLASS_NORMAL
-	custom_price = PAYCHECK_CREW * 5
+	//custom_price = PAYCHECK_CREW * 5
 	wound_bonus = 15
 
 /obj/item/knife/hunting

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -281,7 +281,7 @@
 	desc = "A strange box containing wood working tools and an instruction paper to turn stun batons into something else."
 	icon = 'icons/obj/storage/storage.dmi'
 	icon_state = "uk"
-	custom_price = PAYCHECK_COMMAND * 4.5
+	//custom_price = PAYCHECK_COMMAND * 4.5
 
 /obj/item/melee/baton/telescopic
 	name = "telescopic baton"

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -90,8 +90,8 @@
 	desc = "A handheld tracking device that points to crew suit sensors."
 	icon_state = "pinpointer_crew"
 	worn_icon_state = "pinpointer_crew"
-	custom_price = PAYCHECK_CREW * 4
-	custom_premium_price = PAYCHECK_CREW * 6
+	//custom_price = PAYCHECK_CREW * 4
+	//custom_premium_price = PAYCHECK_CREW * 6
 	var/has_owner = FALSE
 	var/pinpointer_owner = null
 	var/ignore_suit_sensor_level = FALSE /// Do we find people even if their suit sensors are turned off

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -131,7 +131,7 @@
 	max_amount = 12
 	amount = 6
 	grind_results = list(/datum/reagent/cellulose = 2)
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2
 	absorption_rate = 0.125
 	absorption_capacity = 5
 	splint_factor = 0.7

--- a/code/game/objects/items/stacks/tape.dm
+++ b/code/game/objects/items/stacks/tape.dm
@@ -116,7 +116,7 @@
 	prefix = "surgical"
 	conferred_embed = list("embed_chance" = 30, "pain_mult" = 0, "jostle_pain_mult" = 0, "ignore_throwspeed_threshold" = TRUE)
 	splint_factor = 0.5
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	merge_type = /obj/item/stack/sticky_tape/surgical
 	greyscale_colors = "#70BAE7#BD6A62"
 	tape_gag = /obj/item/clothing/mask/muzzle/tape/surgical

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -330,7 +330,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	custom_materials = list(/datum/material/iron=3000)
-	custom_price = PAYCHECK_CREW * 0.6
+	//custom_price = PAYCHECK_CREW * 0.6
 
 /obj/item/storage/bag/tray/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -38,7 +38,7 @@
 	inhand_icon_state = "utility"
 	worn_icon_state = "utility"
 	content_overlays = TRUE
-	custom_premium_price = PAYCHECK_CREW * 2
+	//custom_premium_price = PAYCHECK_CREW * 2
 	drop_sound = 'sound/items/handling/toolbelt_drop.ogg'
 	pickup_sound = 'sound/items/handling/toolbelt_pickup.ogg'
 
@@ -356,7 +356,7 @@
 	inhand_icon_state = "securitywebbing"
 	worn_icon_state = "securitywebbing"
 	content_overlays = FALSE
-	custom_premium_price = PAYCHECK_COMMAND * 3
+	//custom_premium_price = PAYCHECK_COMMAND * 3
 
 /obj/item/storage/belt/security/webbing/Initialize(mapload)
 	. = ..()
@@ -704,7 +704,7 @@
 	inhand_icon_state = null
 	worn_icon_state = "fannypack_leather"
 	dying_key = DYE_REGISTRY_FANNYPACK
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2
 
 /obj/item/storage/belt/fannypack/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/boxes/food_boxes.dm
+++ b/code/game/objects/items/storage/boxes/food_boxes.dm
@@ -324,7 +324,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	illustration = null
 	foldable = null
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/storage/box/gum/Initialize(mapload)
 	. = ..()
@@ -339,7 +339,7 @@
 	name = "nicotine gum packet"
 	desc = "Designed to help with nicotine addiction and oral fixation all at once without destroying your lungs in the process. Mint flavored!"
 	icon_state = "bubblegum_nicotine"
-	custom_premium_price = PAYCHECK_CREW * 1.5
+	//custom_premium_price = PAYCHECK_CREW * 1.5
 
 /obj/item/storage/box/gum/nicotine/PopulateContents()
 	for(var/i in 1 to 4)
@@ -349,8 +349,8 @@
 	name = "HP+ gum packet"
 	desc = "A seemingly homemade packaging with an odd smell. It has a weird drawing of a smiling face sticking out its tongue."
 	icon_state = "bubblegum_happiness"
-	custom_price = PAYCHECK_COMMAND * 3
-	custom_premium_price = PAYCHECK_COMMAND * 3
+	//custom_price = PAYCHECK_COMMAND * 3
+	//custom_premium_price = PAYCHECK_COMMAND * 3
 
 /obj/item/storage/box/gum/happiness/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/boxes/service_boxes.dm
+++ b/code/game/objects/items/storage/boxes/service_boxes.dm
@@ -83,7 +83,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	drop_sound = 'sound/items/handling/matchbox_drop.ogg'
 	pickup_sound = 'sound/items/handling/matchbox_pickup.ogg'
-	custom_price = PAYCHECK_CREW * 0.4
+	//custom_price = PAYCHECK_CREW * 0.4
 	base_icon_state = "matchbox"
 	illustration = null
 
@@ -162,7 +162,7 @@
 /obj/item/storage/box/dishdrive
 	name = "DIY Dish Drive Kit"
 	desc = "Contains everything you need to build your own Dish Drive!"
-	custom_premium_price = PAYCHECK_CREW * 3
+	//custom_premium_price = PAYCHECK_CREW * 3
 
 /obj/item/storage/box/dishdrive/PopulateContents()
 	var/static/items_inside = list(
@@ -190,7 +190,7 @@
 /obj/item/storage/box/tail_pin
 	name = "pin the tail on the corgi supplies"
 	desc = "For ages 10 and up. ...Why is this even on a space station? Aren't you a little old for babby games?" //Intentional typo.
-	custom_price = PAYCHECK_COMMAND * 1.25
+	//custom_price = PAYCHECK_COMMAND * 1.25
 
 /obj/item/storage/box/tail_pin/PopulateContents()
 	for(var/i in 1 to 3)

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -95,7 +95,7 @@
 	spawn_count = 6
 	is_open = TRUE
 	appearance_flags = KEEP_TOGETHER|LONG_GLIDE
-	custom_premium_price = PAYCHECK_COMMAND * 1.75
+	//custom_premium_price = PAYCHECK_COMMAND * 1.75
 	contents_tag = "donut"
 
 /obj/item/storage/fancy/donut_box/Initialize(mapload)
@@ -191,7 +191,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	spawn_type = /obj/item/clothing/mask/cigarette/space_cigarette
 	spawn_count = 6
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	age_restricted = TRUE
 	contents_tag = "cigarette"
 	///for cigarette overlay
@@ -355,7 +355,7 @@
 	contents_tag = "rolling paper"
 	spawn_type = /obj/item/rollingpaper
 	spawn_count = 10
-	custom_price = PAYCHECK_LOWER
+	//custom_price = PAYCHECK_LOWER
 	has_open_closed_states = FALSE
 
 /obj/item/storage/fancy/rollingpapers/Initialize(mapload)

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -240,7 +240,7 @@
 	desc = "An advanced kit to help deal with advanced wounds."
 	icon_state = "medkit_advanced"
 	inhand_icon_state = "medkit-rad"
-	custom_premium_price = PAYCHECK_COMMAND * 6
+	//custom_premium_price = PAYCHECK_COMMAND * 6
 	damagetype_healed = "all"
 
 /obj/item/storage/medkit/advanced/PopulateContents()
@@ -522,7 +522,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	throw_speed = 3
 	throw_range = 7
-	custom_premium_price = PAYCHECK_CREW * 4
+	//custom_premium_price = PAYCHECK_CREW * 4
 	/// var to prevent it freezing the same things over and over
 	var/cooling = FALSE
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -147,7 +147,7 @@
 	desc = "A janitorial cleaner backpack with nozzle to clean blood and graffiti."
 	icon_state = "waterbackpackjani"
 	inhand_icon_state = "waterbackpackjani"
-	custom_price = PAYCHECK_CREW * 5
+	//custom_price = PAYCHECK_CREW * 5
 
 /obj/item/watertank/janitor/Initialize(mapload)
 	. = ..()
@@ -178,7 +178,7 @@
 	icon = 'icons/obj/hydroponics/equipment.dmi'
 	icon_state = "pepperbackpacksec"
 	inhand_icon_state = "pepperbackpacksec"
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2
 	volume = 1000
 
 /obj/item/watertank/pepperspray/Initialize(mapload)

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -311,7 +311,7 @@ GLOBAL_LIST_EMPTY(tcgcard_radial_choices)
 	icon = 'icons/obj/toys/tcgmisc.dmi'
 	icon_state = "cardback_nt"
 	w_class = WEIGHT_CLASS_TINY
-	custom_price = PAYCHECK_CREW * 2 //Effectively expensive as long as you're not a very high paying job... in which case, why are you playing trading card games?
+	//custom_price = PAYCHECK_CREW * 2 //Effectively expensive as long as you're not a very high paying job... in which case, why are you playing trading card games?
 	///The card series to look in
 	var/series = "MEME"
 	///Chance of the pack having a coin in it out of 10

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -208,7 +208,7 @@
 	desc = "Every captain's greatest ally when exploring the vast emptiness of space, now with a color display!"
 	icon = 'icons/obj/toys/toy.dmi'
 	icon_state = "captainsaid_off"
-	custom_price = PAYCHECK_COMMAND * 1.25
+	//custom_price = PAYCHECK_COMMAND * 1.25
 
 	/// List of modes it can cycle through
 	var/list/modes = list(
@@ -1376,7 +1376,7 @@ GLOBAL_LIST_EMPTY(intento_players)
 	desc = "Fundamentally useless for all intentsive purposes."
 	icon = 'icons/obj/toys/intents.dmi'
 	icon_state = "blank"
-	custom_price = PAYCHECK_COMMAND * 1.25
+	//custom_price = PAYCHECK_COMMAND * 1.25
 
 	/// Current sequence of intents
 	var/list/current_sequence = list()

--- a/code/game/objects/items/wall_mounted.dm
+++ b/code/game/objects/items/wall_mounted.dm
@@ -90,4 +90,4 @@
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50, /datum/material/glass=50)
 	grind_results = list(/datum/reagent/iron = 10, /datum/reagent/silicon = 10)
-	custom_price = PAYCHECK_CREW * 0.5
+	//custom_price = PAYCHECK_CREW * 0.5

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -648,7 +648,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "skateboard2"
 	inhand_icon_state = "skateboard2"
 	board_item_type = /obj/vehicle/ridden/scooter/skateboard/pro
-	custom_premium_price = PAYCHECK_COMMAND * 5
+	//custom_premium_price = PAYCHECK_COMMAND * 5
 
 /obj/item/melee/skateboard/hoverboard
 	name = "hoverboard"
@@ -656,7 +656,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	icon_state = "hoverboard_red"
 	inhand_icon_state = "hoverboard_red"
 	board_item_type = /obj/vehicle/ridden/scooter/skateboard/hoverboard
-	custom_premium_price = PAYCHECK_COMMAND * 5.4 //If I can't make it a meme I'll make it RAD
+	//custom_premium_price = PAYCHECK_COMMAND * 5.4 //If I can't make it a meme I'll make it RAD
 
 /obj/item/melee/skateboard/hoverboard/admin
 	name = "Board Of Directors"

--- a/code/game/objects/structures/lavaland/geyser.dm
+++ b/code/game/objects/structures/lavaland/geyser.dm
@@ -185,4 +185,4 @@
 	plunge_mod = 0.5
 	layer_mode_sprite = "reinforced_plunger_layer"
 
-	custom_premium_price = PAYCHECK_CREW * 8
+	//custom_premium_price = PAYCHECK_CREW * 8

--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -75,7 +75,7 @@
 	base_pixel_x = 11
 	base_pixel_y = 10
 
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/canvas/Initialize(mapload)
 	. = ..()
@@ -399,7 +399,7 @@
 	pixels_per_unit = 20
 	w_class = WEIGHT_CLASS_BULKY
 
-	custom_price = PAYCHECK_CREW * 1.25
+	//custom_price = PAYCHECK_CREW * 1.25
 
 /obj/item/canvas/thirtysix_twentyfour/Initialize(mapload)
 	. = ..()
@@ -422,7 +422,7 @@
 	pixels_per_unit = 18
 	w_class = WEIGHT_CLASS_BULKY
 
-	custom_price = PAYCHECK_CREW * 1.75
+	//custom_price = PAYCHECK_CREW * 1.75
 
 /obj/item/canvas/fortyfive_twentyseven/Initialize(mapload)
 	. = ..()
@@ -626,7 +626,7 @@
 	icon_state = "frame-large-empty"
 	result_path = /obj/structure/sign/painting/large
 	pixel_shift = 0 //See [/obj/structure/sign/painting/large/proc/finalize_size]
-	custom_price = PAYCHECK_CREW * 1.25
+	//custom_price = PAYCHECK_CREW * 1.25
 
 /obj/item/wallframe/painting/large/try_build(turf/on_wall, mob/user)
 	. = ..()

--- a/code/modules/cargo/packs/vending_restock.dm
+++ b/code/modules/cargo/packs/vending_restock.dm
@@ -3,8 +3,9 @@
 
 /datum/supply_pack/vending/bartending
 	name = "Booze-o-mat and Coffee Supply Crate"
-	desc = "Bring on the booze and coffee vending machine refills."
-	cost = CARGO_CRATE_VALUE * 4
+	desc = "Bring on the booze and coffee vending machine refills. \
+		Microcharges may apply."
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/boozeomat,
 					/obj/item/vending_refill/coffee,
 				)
@@ -13,8 +14,8 @@
 /datum/supply_pack/vending/cigarette
 	name = "Cigarette Supply Crate"
 	desc = "Don't believe the reports - smoke today! Contains a \
-		cigarette vending machine refill."
-	cost = CARGO_CRATE_VALUE * 3
+		cigarette vending machine refill. Microcharges may apply."
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/cigarette)
 	crate_name = "cigarette supply crate"
 	crate_type = /obj/structure/closet/crate
@@ -22,21 +23,21 @@
 /datum/supply_pack/vending/dinnerware
 	name = "Dinnerware Supply Crate"
 	desc = "More knives for the chef."
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/dinnerware)
 	crate_name = "dinnerware supply crate"
 
 /datum/supply_pack/vending/science/modularpc
 	name = "Deluxe Silicate Selections Restock"
 	desc = "What's a computer? Contains a Deluxe Silicate Selections restocking unit."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 5
 	contains = list(/obj/item/vending_refill/modularpc)
 	crate_name = "computer supply crate"
 
 /datum/supply_pack/vending/engivend
 	name = "EngiVend Supply Crate"
 	desc = "The engineers are out of metal foam grenades? This should help."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/vending_refill/engivend)
 	crate_name = "engineering supply crate"
 
@@ -62,7 +63,7 @@
 /datum/supply_pack/vending/imported
 	name = "Imported Vending Machines"
 	desc = "Vending machines famous in other parts of the galaxy."
-	cost = CARGO_CRATE_VALUE * 8
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/vending_refill/sustenance,
 					/obj/item/vending_refill/robotics,
 					/obj/item/vending_refill/sovietsoda,
@@ -74,7 +75,7 @@
 	name = "Medical Vending Crate"
 	desc = "Contains one NanoMed Plus refill, one NanoDrug Plus refill, \
 		and one wall-mounted NanoMed refill."
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/vending_refill/medical,
 					/obj/item/vending_refill/drugs,
 					/obj/item/vending_refill/wallmed,
@@ -85,7 +86,7 @@
 	name = "PTech Supply Crate"
 	desc = "Not enough cartridges after half the crew lost their PDA \
 		to explosions? This may fix it."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/cart)
 	crate_name = "\improper PTech supply crate"
 
@@ -93,7 +94,7 @@
 	name = "SecTech Supply Crate"
 	desc = "Officer Paul bought all the donuts? Then refill the security \
 		vendor with this crate."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 6
 	access = ACCESS_SECURITY
 	contains = list(/obj/item/vending_refill/security)
 	crate_name = "\improper SecTech supply crate"
@@ -102,23 +103,24 @@
 /datum/supply_pack/vending/snack
 	name = "Snack Supply Crate"
 	desc = "One vending machine refill of cavity-bringin' goodness! \
-		The number one dentist recommended order!"
-	cost = CARGO_CRATE_VALUE * 3
+		The number one dentist recommended order! Microcharges may apply."
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/snack)
 	crate_name = "snacks supply crate"
 
 /datum/supply_pack/vending/cola
 	name = "Softdrinks Supply Crate"
 	desc = "Got whacked by a toolbox, but you still have those pesky teeth? \
-		Get rid of those pearly whites with this soda machine refill, today!"
-	cost = CARGO_CRATE_VALUE * 3
+		Get rid of those pearly whites with this soda machine refill, today! \
+		Microcharges may apply."
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/cola)
 	crate_name = "soft drinks supply crate"
 
 /datum/supply_pack/vending/vendomat
 	name = "Part-Mart & YouTool Supply Crate"
 	desc = "More tools for your IED testing facility."
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/assist,
 					/obj/item/vending_refill/youtool,
 				)
@@ -127,7 +129,7 @@
 /datum/supply_pack/vending/clothesmate
 	name = "ClothesMate Supply Crate"
 	desc = "Out of cowboy boots? Buy this crate."
-	cost = CARGO_CRATE_VALUE * 2
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/clothing)
 	crate_name = "\improper ClothesMate supply crate"
 
@@ -138,21 +140,21 @@
 	name = "Autodrobe Supply Crate"
 	desc = "Autodrobe missing your favorite dress? Solve that issue today \
 		with this autodrobe refill."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/autodrobe)
 	crate_name = "autodrobe supply crate"
 
 /datum/supply_pack/vending/wardrobes/cargo
 	name = "Cargo Wardrobe Supply Crate"
 	desc = "This crate contains a refill for the CargoDrobe."
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/wardrobe/cargo_wardrobe)
 	crate_name = "cargo department supply crate"
 
 /datum/supply_pack/vending/wardrobes/engineering
 	name = "Engineering Wardrobe Supply Crate"
 	desc = "This crate contains refills for the EngiDrobe and AtmosDrobe."
-	cost = CARGO_CRATE_VALUE * 3
+	cost = CARGO_CRATE_VALUE * 2
 	contains = list(/obj/item/vending_refill/wardrobe/engi_wardrobe,
 					/obj/item/vending_refill/wardrobe/atmos_wardrobe,
 				)
@@ -162,7 +164,7 @@
 	name = "General Wardrobes Supply Crate"
 	desc = "This crate contains refills for the CuraDrobe, BarDrobe, \
 		ChefDrobe and ChapDrobe."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3
 	contains = list(/obj/item/vending_refill/wardrobe/curator_wardrobe,
 					/obj/item/vending_refill/wardrobe/bar_wardrobe,
 					/obj/item/vending_refill/wardrobe/chef_wardrobe,
@@ -173,14 +175,14 @@
 /datum/supply_pack/vending/wardrobes/hydroponics
 	name = "Hydrobe Supply Crate"
 	desc = "This crate contains a refill for the Hydrobe."
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE * 1
 	contains = list(/obj/item/vending_refill/wardrobe/hydro_wardrobe)
 	crate_name = "hydrobe supply crate"
 
 /datum/supply_pack/vending/wardrobes/janitor
 	name = "JaniDrobe Supply Crate"
 	desc = "This crate contains a refill for the JaniDrobe."
-	cost = CARGO_CRATE_VALUE * 1.5
+	cost = CARGO_CRATE_VALUE * 4
 	contains = list(/obj/item/vending_refill/wardrobe/jani_wardrobe)
 	crate_name = "janidrobe supply crate"
 
@@ -188,7 +190,7 @@
 	name = "Medical Wardrobe Supply Crate"
 	desc = "This crate contains refills for the MediDrobe, \
 		ChemDrobe, and ViroDrobe."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 8
 	contains = list(/obj/item/vending_refill/wardrobe/medi_wardrobe,
 					/obj/item/vending_refill/wardrobe/chem_wardrobe,
 					/obj/item/vending_refill/wardrobe/viro_wardrobe,
@@ -210,7 +212,7 @@
 	name = "Security Wardrobe Supply Crate"
 	desc = "This crate contains refills for the SecDrobe, \
 		DetDrobe and LawDrobe."
-	cost = CARGO_CRATE_VALUE * 4
+	cost = CARGO_CRATE_VALUE * 6
 	contains = list(/obj/item/vending_refill/wardrobe/sec_wardrobe,
 					/obj/item/vending_refill/wardrobe/det_wardrobe,
 					/obj/item/vending_refill/wardrobe/law_wardrobe,

--- a/code/modules/clothing/ears/_ears.dm
+++ b/code/modules/clothing/ears/_ears.dm
@@ -18,7 +18,7 @@
 	strip_delay = 15
 	equip_delay_other = 25
 	resistance_flags = FLAMMABLE
-	custom_price = PAYCHECK_COMMAND * 1.5
+	//custom_price = PAYCHECK_COMMAND * 1.5
 
 /obj/item/clothing/ears/earmuffs/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -10,8 +10,8 @@
 	siemens_coefficient = 0
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 	resistance_flags = NONE
-	custom_price = PAYCHECK_CREW * 10
-	custom_premium_price = PAYCHECK_COMMAND * 6
+	//custom_price = PAYCHECK_CREW * 10
+	//custom_premium_price = PAYCHECK_COMMAND * 6
 	cut_type = /obj/item/clothing/gloves/cut
 
 /obj/item/clothing/gloves/color/yellow/heavy
@@ -122,7 +122,7 @@
 	equip_delay_other = 20
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
-	custom_price = PAYCHECK_CREW * 1.5
+	//custom_price = PAYCHECK_CREW * 1.5
 	undyeable = TRUE
 	clothing_traits = list(TRAIT_FINGERPRINT_PASSTHROUGH)
 
@@ -264,7 +264,7 @@
 	desc = "These look pretty fancy."
 	icon_state = "white"
 	greyscale_colors = "#ffffff"
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/clothing/gloves/kim
 	name = "aerostatic gloves"

--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -6,7 +6,7 @@
 	cold_protection = HANDS
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	resistance_flags = NONE
-	custom_premium_price = PAYCHECK_COMMAND * 3.5
+	//custom_premium_price = PAYCHECK_COMMAND * 3.5
 	clothing_traits = list(TRAIT_FINGERPRINT_PASSTHROUGH)
 	/// For storing our tackler datum so we can remove it after
 	var/datum/component/tackler

--- a/code/modules/clothing/head/beanie.dm
+++ b/code/modules/clothing/head/beanie.dm
@@ -9,7 +9,7 @@
 	icon = 'icons/obj/clothing/head/beanie.dmi'
 	worn_icon = 'icons/mob/clothing/head/beanie.dmi'
 	icon_state = "beanie"
-	custom_price = PAYCHECK_CREW * 1.2
+	//custom_price = PAYCHECK_CREW * 1.2
 	greyscale_colors = "#EEEEEE#EEEEEE"
 	greyscale_config = /datum/greyscale_config/beanie
 	greyscale_config_worn = /datum/greyscale_config/beanie_worn

--- a/code/modules/clothing/head/hat.dm
+++ b/code/modules/clothing/head/hat.dm
@@ -16,7 +16,7 @@
 	desc = "A british looking helmet."
 	icon_state = "constable"
 	inhand_icon_state = null
-	custom_price = PAYCHECK_COMMAND * 1.5
+	//custom_price = PAYCHECK_COMMAND * 1.5
 	worn_y_offset = 4
 
 /obj/item/clothing/head/costume/spacepolice

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -100,7 +100,7 @@
 	desc = "A reliable, blue tinted helmet reminding you that you <i>still</i> owe that engineer a beer."
 	icon_state = "blueshift"
 	inhand_icon_state = "blueshift_helmet"
-	custom_premium_price = PAYCHECK_COMMAND
+	//custom_premium_price = PAYCHECK_COMMAND
 
 
 /obj/item/clothing/head/helmet/toggleable

--- a/code/modules/clothing/head/wig.dm
+++ b/code/modules/clothing/head/wig.dm
@@ -96,7 +96,7 @@
 	desc = "A bunch of hair without a head attached. This one changes color to match the hair of the wearer. Nothing natural about that."
 	color = "#FFFFFF"
 	adjustablecolor = FALSE
-	custom_price = PAYCHECK_COMMAND
+	//custom_price = PAYCHECK_COMMAND
 
 /obj/item/clothing/head/wig/natural/Initialize(mapload)
 	hairstyle = pick(GLOB.hairstyles_list - "Bald")

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -188,7 +188,7 @@ GLOBAL_LIST_INIT(hailer_phrases, list(
 	icon_state = "whistle"
 	inhand_icon_state = null
 	slot_flags = ITEM_SLOT_MASK|ITEM_SLOT_NECK
-	custom_price = PAYCHECK_COMMAND * 1.5
+	//custom_price = PAYCHECK_COMMAND * 1.5
 	w_class = WEIGHT_CLASS_SMALL
 	actions_types = list(/datum/action/item_action/halt)
 	COOLDOWN_DECLARE(whistle_cooldown)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -24,7 +24,7 @@
 	icon_state = "tie_greyscale_tied"
 	inhand_icon_state = "" //no inhands
 	w_class = WEIGHT_CLASS_SMALL
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_config = /datum/greyscale_config/ties
 	greyscale_config_worn = /datum/greyscale_config/ties_worn
 	greyscale_colors = "#4d4e4e"
@@ -213,7 +213,7 @@
 	icon_state = "scarf"
 	desc = "A stylish scarf. The perfect winter accessory for those with a keen fashion sense, and those who just can't handle a cold breeze on their necks."
 	w_class = WEIGHT_CLASS_TINY
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#EEEEEE#EEEEEE"
 	greyscale_config = /datum/greyscale_config/scarf
 	greyscale_config_worn = /datum/greyscale_config/scarf_worn
@@ -267,7 +267,7 @@
 	name = "large scarf"
 	icon_state = "large_scarf"
 	w_class = WEIGHT_CLASS_TINY
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#C6C6C6#EEEEEE"
 	greyscale_config = /datum/greyscale_config/large_scarf
 	greyscale_config_worn = /datum/greyscale_config/large_scarf_worn
@@ -295,7 +295,7 @@
 	name = "infinity scarf"
 	icon_state = "infinity_scarf"
 	w_class = WEIGHT_CLASS_TINY
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#EEEEEE"
 	greyscale_config = /datum/greyscale_config/infinity_scarf
 	greyscale_config_worn = /datum/greyscale_config/infinity_scarf_worn
@@ -361,7 +361,7 @@
 	icon = 'icons/obj/clothing/neck.dmi'
 	icon_state = "beads"
 	color = "#ffffff"
-	custom_price = PAYCHECK_CREW * 0.2
+	//custom_price = PAYCHECK_CREW * 0.2
 	custom_materials = (list(/datum/material/plastic = 500))
 
 /obj/item/clothing/neck/beads/Initialize(mapload)

--- a/code/modules/clothing/shoes/cowboy.dm
+++ b/code/modules/clothing/shoes/cowboy.dm
@@ -3,7 +3,7 @@
 	desc = "A small sticker lets you know they've been inspected for snakes, It is unclear how long ago the inspection took place..."
 	icon_state = "cowboy_brown"
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 90, FIRE = 0, ACID = 0) //these are quite tall
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	var/max_occupants = 4
 	can_be_tied = FALSE
 

--- a/code/modules/clothing/shoes/galoshes.dm
+++ b/code/modules/clothing/shoes/galoshes.dm
@@ -10,7 +10,7 @@
 	resistance_flags = NONE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 40, ACID = 75)
 	can_be_bloody = FALSE
-	custom_price = PAYCHECK_CREW * 3
+	//custom_price = PAYCHECK_CREW * 3
 	can_be_tied = FALSE
 
 /obj/item/clothing/shoes/galoshes/dry

--- a/code/modules/clothing/shoes/sneakers.dm
+++ b/code/modules/clothing/shoes/sneakers.dm
@@ -14,7 +14,7 @@
 /obj/item/clothing/shoes/sneakers/black
 	name = "black shoes"
 	desc = "A pair of black shoes."
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 	cold_protection = FEET
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -68,8 +68,8 @@
 	worn_icon_state = "rollerskates"
 	slowdown = SHOES_SLOWDOWN+1
 	wheels = /obj/vehicle/ridden/scooter/skateboard/wheelys/rollerskates
-	custom_premium_price = PAYCHECK_CREW * 5
-	custom_price = PAYCHECK_CREW * 5
+	//custom_premium_price = PAYCHECK_CREW * 5
+	//custom_price = PAYCHECK_CREW * 5
 
 /obj/item/clothing/shoes/wheelys/skishoes
 	name = "ski shoes"
@@ -81,5 +81,5 @@
 	worn_icon_state = "skishoes"
 	slowdown = SHOES_SLOWDOWN+1
 	wheels = /obj/vehicle/ridden/scooter/skateboard/wheelys/skishoes
-	custom_premium_price = PAYCHECK_CREW * 1.6
-	custom_price = PAYCHECK_CREW * 1.6
+	//custom_premium_price = PAYCHECK_CREW * 1.6
+	//custom_price = PAYCHECK_CREW * 1.6

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -72,7 +72,7 @@
 	desc = "A large, yet comfortable piece of armor, protecting you from some threats."
 	icon_state = "blueshift"
 	inhand_icon_state = null
-	custom_premium_price = PAYCHECK_COMMAND
+	//custom_premium_price = PAYCHECK_COMMAND
 
 /obj/item/clothing/suit/armor/vest/cuirass
 	name = "cuirass"

--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -256,7 +256,7 @@
 /obj/item/clothing/under/costume/buttondown
 	gender = PLURAL
 	female_sprite_flags = NO_FEMALE_UNIFORM
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	icon = 'icons/obj/clothing/under/shorts_pants_shirts.dmi'
 	worn_icon = 'icons/mob/clothing/under/shorts_pants_shirts.dmi'
 	species_exception = list(/datum/species/golem)

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -59,7 +59,7 @@
 	icon_state = "constable"
 	inhand_icon_state = null
 	can_adjust = FALSE
-	custom_price = PAYCHECK_COMMAND
+	//custom_price = PAYCHECK_COMMAND
 
 
 /obj/item/clothing/under/rank/security/warden

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -70,7 +70,7 @@
 	icon_state = "overalls"
 	inhand_icon_state = "lb_suit"
 	can_adjust = FALSE
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/clothing/under/misc/assistantformal
 	name = "assistant's formal uniform"

--- a/code/modules/clothing/under/pants.dm
+++ b/code/modules/clothing/under/pants.dm
@@ -3,7 +3,7 @@
 	body_parts_covered = GROIN|LEGS
 	female_sprite_flags = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	icon = 'icons/obj/clothing/under/shorts_pants_shirts.dmi'
 	worn_icon = 'icons/mob/clothing/under/shorts_pants_shirts.dmi'
 	species_exception = list(/datum/species/golem)

--- a/code/modules/clothing/under/skirt_dress.dm
+++ b/code/modules/clothing/under/skirt_dress.dm
@@ -45,7 +45,7 @@
 	icon_state = "plaidskirt"
 	can_adjust = TRUE
 	alt_covers_chest = TRUE
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#CC2102"
 	greyscale_config = /datum/greyscale_config/plaidskirt
 	greyscale_config_worn = /datum/greyscale_config/plaidskirt_worn
@@ -55,7 +55,7 @@
 	name = "turtleneck skirt"
 	desc = "A casual turtleneck skirt."
 	icon_state = "turtleskirt"
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#cc0000#5f5f5f"
 	greyscale_config = /datum/greyscale_config/turtleskirt
 	greyscale_config_worn = /datum/greyscale_config/turtleskirt_worn
@@ -65,7 +65,7 @@
 	name = "tango dress"
 	desc = "Filled with Latin fire."
 	icon_state = "tango"
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#ff0000#1c1c1c"
 	greyscale_config = /datum/greyscale_config/tango
 	greyscale_config_worn = /datum/greyscale_config/tango_worn
@@ -75,7 +75,7 @@
 	name = "sundress"
 	desc = "Makes you want to frolic in a field of daisies."
 	icon_state = "sundress"
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	greyscale_colors = "#FFE60F#9194A5#1F243C"
 	greyscale_config = /datum/greyscale_config/sundress
 	greyscale_config_worn = /datum/greyscale_config/sundress_worn

--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -11,7 +11,7 @@
 	icon_dead = "xpod-dead"
 	icon_harvest = "xpod-harvest"
 	growthstages = 4
-	custom_premium_price = PAYCHECK_CREW * 2
+	//custom_premium_price = PAYCHECK_CREW * 2
 
 /obj/item/seeds/random/Initialize(mapload)
 	. = ..()

--- a/code/modules/instruments/items.dm
+++ b/code/modules/instruments/items.dm
@@ -280,5 +280,5 @@
 	w_class = WEIGHT_CLASS_TINY
 	force = 0
 	hitsound = 'sound/voice/moth/scream_moth.ogg'
-	custom_price = PAYCHECK_COMMAND * 2.37
-	custom_premium_price = PAYCHECK_COMMAND * 2.37
+	//custom_price = PAYCHECK_COMMAND * 2.37
+	//custom_premium_price = PAYCHECK_COMMAND * 2.37

--- a/code/modules/instruments/piano_synth.dm
+++ b/code/modules/instruments/piano_synth.dm
@@ -25,7 +25,7 @@
 	slot_flags = ITEM_SLOT_EARS | ITEM_SLOT_HEAD
 	force = 0
 	w_class = WEIGHT_CLASS_SMALL
-	custom_price = PAYCHECK_CREW * 2.5
+	//custom_price = PAYCHECK_CREW * 2.5
 	instrument_range = 1
 	circuit_type = /obj/item/circuit_component/synth/headphones
 	shell_capacity = SHELL_CAPACITY_TINY
@@ -60,7 +60,7 @@
 	slot_flags = ITEM_SLOT_EARS
 	strip_delay = 100 //air pods don't fall out
 	instrument_range = 0 //you're paying for quality here
-	custom_premium_price = PAYCHECK_CREW * 36 //Save up 5 shifts worth of pay just to lose it down a drainpipe on the sidewalk
+	//custom_premium_price = PAYCHECK_CREW * 36 //Save up 5 shifts worth of pay just to lose it down a drainpipe on the sidewalk
 
 /obj/item/circuit_component/synth
 	display_name = "Synthesizer"

--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -11,7 +11,7 @@
 
 	icon = 'icons/obj/card.dmi'
 	icon_state = "data_3"
-	custom_price = PAYCHECK_CREW * 3
+	//custom_price = PAYCHECK_CREW * 3
 	w_class = WEIGHT_CLASS_SMALL
 
 	/// Traits automatically granted by this chip, optional. Lazylist.

--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -1,5 +1,5 @@
 /obj/item/pai_card
-	custom_premium_price = PAYCHECK_COMMAND * 1.25
+	//custom_premium_price = PAYCHECK_COMMAND * 1.25
 	desc = "Downloads personal AI assistants to accompany its owner or others."
 	icon = 'icons/obj/aicards.dmi'
 	icon_state = "pai"

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -19,7 +19,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_NECK
 	custom_materials = list(/datum/material/iron = 50, /datum/material/glass = 150)
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2
 	var/flash_enabled = TRUE
 	var/state_on = "camera"
 	var/state_off = "camera_off"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -411,7 +411,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 
 /obj/item/stack/cable_coil
 	name = "cable coil"
-	custom_price = PAYCHECK_LOWER * 0.8
+	//custom_price = PAYCHECK_LOWER * 0.8
 	gender = NEUTER //That's a cable coil sounds better than that's some cable coils
 	icon = 'icons/obj/power.dmi'
 	icon_state = "coil"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -408,7 +408,7 @@
 	connector_type = null
 	custom_materials = null
 	grown_battery = TRUE //it has the overlays for wires
-	custom_premium_price = PAYCHECK_CREW
+	//custom_premium_price = PAYCHECK_CREW
 
 /obj/item/stock_parts/cell/emproof
 	name = "\improper EMP-proof cell"

--- a/code/modules/power/lighting/light_items.dm
+++ b/code/modules/power/lighting/light_items.dm
@@ -33,7 +33,7 @@
 	base_state = "ltube"
 	inhand_icon_state = "c_tube"
 	brightness = 8
-	custom_price = PAYCHECK_CREW * 0.5
+	//custom_price = PAYCHECK_CREW * 0.5
 
 /obj/item/light/tube/broken
 	status = LIGHT_BROKEN
@@ -47,7 +47,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	brightness = 4
-	custom_price = PAYCHECK_CREW * 0.4
+	//custom_price = PAYCHECK_CREW * 0.4
 
 /obj/item/light/bulb/broken
 	status = LIGHT_BROKEN

--- a/code/modules/power/pipecleaners.dm
+++ b/code/modules/power/pipecleaners.dm
@@ -187,7 +187,7 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/item/stack/pipe_cleaner_coil
 	name = "pipe cleaner coil"
 	desc = "A coil of pipe cleaners. Good for arts and crafts, not to build with."
-	custom_price = PAYCHECK_CREW * 0.5
+	//custom_price = PAYCHECK_CREW * 0.5
 	gender = NEUTER //That's a pipe_cleaner coil sounds better than that's some pipe_cleaner coils
 	icon = 'icons/obj/power.dmi'
 	icon_state = "pipecleaner"

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -16,7 +16,7 @@
 	obj_flags = UNIQUE_RENAME
 	drop_sound = 'sound/items/handling/drinkglass_drop.ogg'
 	pickup_sound = 'sound/items/handling/drinkglass_pickup.ogg'
-	custom_price = PAYCHECK_LOWER
+	//custom_price = PAYCHECK_LOWER
 	//the screwdriver cocktail can make a drinking glass into the world's worst screwdriver. beautiful.
 	toolspeed = 25
 
@@ -96,7 +96,7 @@
 	fill_icon_state = "shot_glass"
 	volume = 15
 	custom_materials = list(/datum/material/glass=100)
-	custom_price = PAYCHECK_CREW * 0.4
+	//custom_price = PAYCHECK_CREW * 0.4
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass/update_name(updates)
 	if(renamedByPlayer)

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -128,7 +128,7 @@
 /obj/item/reagent_containers/cup/glass/ice
 	name = "ice cup"
 	desc = "Careful, cold ice, do not chew."
-	custom_price = PAYCHECK_LOWER * 0.6
+	//custom_price = PAYCHECK_LOWER * 0.6
 	icon_state = "icecup"
 	list_reagents = list(/datum/reagent/consumable/ice = 30)
 	spillable = TRUE
@@ -161,7 +161,7 @@
 	list_reagents = list(/datum/reagent/consumable/hot_coco = 15, /datum/reagent/consumable/sugar = 5)
 	drink_type = SUGAR
 	resistance_flags = FREEZE_PROOF
-	custom_price = PAYCHECK_CREW * 1.2
+	//custom_price = PAYCHECK_CREW * 1.2
 
 /obj/item/reagent_containers/cup/glass/mug/nanotrasen
 	name = "\improper Nanotrasen mug"
@@ -192,7 +192,7 @@
 	list_reagents = list(/datum/reagent/consumable/dry_ramen = 15, /datum/reagent/consumable/salt = 3)
 	drink_type = GRAIN
 	isGlass = FALSE
-	custom_price = PAYCHECK_CREW * 0.9
+	//custom_price = PAYCHECK_CREW * 0.9
 
 /obj/item/reagent_containers/cup/glass/waterbottle
 	name = "bottle of water"
@@ -212,7 +212,7 @@
 	var/cap_lost = FALSE
 	var/mutable_appearance/cap_overlay
 	var/flip_chance = 10
-	custom_price = PAYCHECK_LOWER * 0.8
+	//custom_price = PAYCHECK_LOWER * 0.8
 
 /obj/item/reagent_containers/cup/glass/waterbottle/Initialize(mapload)
 	. = ..()
@@ -510,7 +510,7 @@
 /obj/item/reagent_containers/cup/glass/flask
 	name = "flask"
 	desc = "Every good spaceman knows it's a good idea to bring along a couple of pints of whiskey wherever they go."
-	custom_price = PAYCHECK_COMMAND * 2
+	//custom_price = PAYCHECK_COMMAND * 2
 	icon_state = "flask"
 	custom_materials = list(/datum/material/iron=250)
 	volume = 60

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -10,7 +10,7 @@
 	icon_state = "glassbottle"
 	worn_icon_state = "bottle"
 	fill_icon_thresholds = list(0, 10, 20, 30, 40, 50, 60, 70, 80, 90)
-	custom_price = PAYCHECK_CREW * 1.1
+	//custom_price = PAYCHECK_CREW * 1.1
 	amount_per_transfer_from_this = 10
 	volume = 100
 	force = 15 //Smashing bottles over someone's head hurts.
@@ -29,7 +29,7 @@
 	desc = "This blank bottle is unyieldingly anonymous, offering no clues to its contents."
 	icon_state = "glassbottlesmall"
 	volume = 50
-	custom_price = PAYCHECK_CREW * 0.9
+	//custom_price = PAYCHECK_CREW * 0.9
 
 /obj/item/reagent_containers/cup/glass/bottle/smash(mob/living/target, mob/thrower, ranged = FALSE, break_top)
 	if(bartender_check(target) && ranged)
@@ -203,7 +203,7 @@
 	volume = 30
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 30)
 	drink_type = GRAIN | ALCOHOL
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer = 1)
@@ -219,8 +219,8 @@
 	volume = 30
 	list_reagents = list(/datum/reagent/consumable/rootbeer = 30)
 	drink_type = SUGAR | JUNKFOOD
-	custom_price = PAYCHECK_CREW * 1.5
-	custom_premium_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 1.5
+	//custom_premium_price = PAYCHECK_CREW * 2
 
 /obj/item/reagent_containers/cup/glass/bottle/ale
 	name = "Magm-Ale"
@@ -229,7 +229,7 @@
 	volume = 30
 	list_reagents = list(/datum/reagent/consumable/ethanol/ale = 30)
 	drink_type = GRAIN | ALCOHOL
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/reagent_containers/cup/glass/bottle/gin
 	name = "Griffeater gin"
@@ -296,7 +296,7 @@
 	desc = "A 40 full of malt liquor. Kicks stronger than, well, a rabid bear."
 	icon_state = "maltliquorbottle"
 	list_reagents = list(/datum/reagent/consumable/ethanol/beer/maltliquor = 100)
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/reagent_containers/cup/glass/bottle/holywater
 	name = "flask of holy water"
@@ -484,7 +484,7 @@
 /obj/item/reagent_containers/cup/glass/bottle/grenadine
 	name = "Jester Grenadine"
 	desc = "Contains 0% real cherries!"
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	icon_state = "grenadine"
 	list_reagents = list(/datum/reagent/consumable/grenadine = 100)
 	drink_type = FRUIT
@@ -493,7 +493,7 @@
 /obj/item/reagent_containers/cup/glass/bottle/applejack
 	name = "Buckin' Bronco's Applejack"
 	desc = "Kicks like a horse, tastes like an apple!"
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	icon_state = "applejack_bottle"
 	list_reagents = list(/datum/reagent/consumable/ethanol/applejack = 100)
 	drink_type = FRUIT
@@ -815,7 +815,7 @@
  * Meant to be a subtype for use in Molotovs
  */
 /obj/item/reagent_containers/cup/glass/bottle/juice
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 	inhand_icon_state = "carton"
 	lefthand_file = 'icons/mob/inhands/items/drinks_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/drinks_righthand.dmi'

--- a/code/modules/reagents/reagent_containers/cups/soda.dm
+++ b/code/modules/reagents/reagent_containers/cups/soda.dm
@@ -11,7 +11,7 @@
 	icon = 'icons/obj/drinks.dmi'
 	reagent_flags = NONE
 	spillable = FALSE
-	custom_price = PAYCHECK_CREW * 0.9
+	//custom_price = PAYCHECK_CREW * 0.9
 	obj_flags = CAN_BE_HIT
 	possible_transfer_amounts = list(5, 10, 15, 25, 30)
 	volume = 30

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -9,7 +9,7 @@
 	possible_transfer_amounts = list(1, 2, 3, 4, 5)
 	volume = 5
 	reagent_flags = TRANSPARENT
-	custom_price = PAYCHECK_CREW
+	//custom_price = PAYCHECK_CREW
 
 /obj/item/reagent_containers/dropper/afterattack(obj/target, mob/user , proximity)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -114,8 +114,8 @@
 	reagent_flags = DRAWABLE
 	flags_1 = null
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/toxin/formaldehyde = 3, /datum/reagent/medicine/coagulant = 2)
-	custom_price = PAYCHECK_CREW
-	custom_premium_price = PAYCHECK_COMMAND
+	//custom_price = PAYCHECK_CREW
+	//custom_premium_price = PAYCHECK_COMMAND
 	var/label_examine = TRUE
 	var/label_text
 

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -22,7 +22,7 @@
 	var/apply_type = PATCH
 	var/apply_method = "spray" //the thick gel is sprayed and then dries into patch like film.
 	var/self_delay = 30
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2
 	unique_reskin = list(
 		"Blue" = "medigel_blue",
 		"Cyan" = "medigel_cyan",
@@ -90,7 +90,7 @@
 	icon_state = "synthgel"
 	current_skin = "synthgel"
 	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 60)
-	custom_price = PAYCHECK_CREW * 5
+	//custom_price = PAYCHECK_CREW * 5
 
 /obj/item/reagent_containers/medigel/sterilizine
 	name = "sterilizer gel"
@@ -98,4 +98,4 @@
 	icon_state = "medigel_blue"
 	current_skin = "medigel_blue"
 	list_reagents = list(/datum/reagent/space_cleaner/sterilizine = 60)
-	custom_price = PAYCHECK_CREW * 2
+	//custom_price = PAYCHECK_CREW * 2

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -380,7 +380,7 @@
 	spray_range = 4
 	stream_range = 2
 	volume = 100
-	custom_premium_price = PAYCHECK_COMMAND * 2
+	//custom_premium_price = PAYCHECK_COMMAND * 2
 
 /obj/item/reagent_containers/spray/syndicate/Initialize(mapload)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -13,7 +13,7 @@
 	volume = 15
 	custom_materials = list(/datum/material/iron=10, /datum/material/glass=20)
 	reagent_flags = TRANSPARENT
-	custom_price = PAYCHECK_CREW * 0.5
+	//custom_price = PAYCHECK_CREW * 0.5
 	sharpness = SHARP_POINTY
 	/// Flags used by the injection
 	var/inject_flags = NONE

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -405,7 +405,7 @@
 	attack_verb_continuous = list("shears", "snips")
 	attack_verb_simple = list("shear", "snip")
 	sharpness = SHARP_EDGED
-	custom_premium_price = PAYCHECK_CREW * 14
+	//custom_premium_price = PAYCHECK_CREW * 14
 
 /obj/item/shears/attack(mob/living/amputee, mob/living/user)
 	if(!iscarbon(amputee) || user.combat_mode)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -154,9 +154,9 @@
 	///Bills we accept?
 	var/obj/item/stack/spacecash/bill
 	///Default price of items if not overridden
-	var/default_price = 25
+	var/default_price = 0
 	///Default price of premium items if not overridden
-	var/extra_price = 50
+	var/extra_price = 0
 	///Whether our age check is currently functional
 	var/age_restrictions = TRUE
 	/**
@@ -1423,7 +1423,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 /obj/item/vending_refill/custom
 	machine_name = "Custom Vendor"
 	icon_state = "refill_custom"
-	custom_premium_price = PAYCHECK_CREW
+	//custom_premium_price = PAYCHECK_CREW
 
 /obj/machinery/vending/custom/greed //name and like decided by the spawn
 	icon_state = "greed"

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -31,8 +31,6 @@
 
 	refill_canister = /obj/item/vending_refill/assist
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
-	default_price = PAYCHECK_CREW * 0.7 //Default of 35.
-	extra_price = PAYCHECK_CREW
 	payment_department = NO_FREEBIES
 	light_mask = "parts-light-mask"
 

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -219,8 +219,6 @@
 		/obj/item/clothing/suit/hooded/wintercoat/cosmic = 1, //ORBSTATION
 	)
 	refill_canister = /obj/item/vending_refill/autodrobe
-	default_price = PAYCHECK_CREW * 0.8 //Default of 40.
-	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 	light_mask="theater-light-mask"
 

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -79,8 +79,8 @@
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
 	req_access = list(ACCESS_BAR)
 	refill_canister = /obj/item/vending_refill/boozeomat
-	default_price = PAYCHECK_CREW * 0.9
-	extra_price = PAYCHECK_COMMAND
+	default_price = 25
+	extra_price = 50
 	payment_department = ACCOUNT_SRV
 	light_mask = "boozeomat-light-mask"
 

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -16,8 +16,6 @@
 		/obj/item/modular_computer/tablet/pda/heads = 10,
 	)
 	refill_canister = /obj/item/vending_refill/cart
-	default_price = PAYCHECK_COMMAND
-	extra_price = PAYCHECK_COMMAND * 2.5
 	payment_department = ACCOUNT_SRV
 	light_mask="cart-light-mask"
 

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -29,8 +29,8 @@
 	)
 
 	refill_canister = /obj/item/vending_refill/cigarette
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND
+	default_price = 50
+	extra_price = 125
 	payment_department = ACCOUNT_SRV
 	light_mask = "cigs-light-mask"
 

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -198,8 +198,6 @@
 		/obj/item/instrument/piano_synth/headphones/spacepods = 1,
 	)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = PAYCHECK_CREW * 0.7 //Default of
-	extra_price = PAYCHECK_COMMAND
 	payment_department = NO_FREEBIES
 	light_mask = "wardrobe-light-mask"
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -30,8 +30,8 @@
 		/obj/item/reagent_containers/cup/glass/bottle/rootbeer = 1,
 	)
 	refill_canister = /obj/item/vending_refill/cola
-	default_price = PAYCHECK_CREW * 0.7
-	extra_price = PAYCHECK_CREW
+	default_price = 25
+	extra_price = 75
 	payment_department = ACCOUNT_SRV
 
 

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -29,8 +29,6 @@
 		/obj/item/knife/butcher = 2,
 	)
 	refill_canister = /obj/item/vending_refill/dinnerware
-	default_price = PAYCHECK_CREW * 0.8
-	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 	light_mask = "dinnerware-light-mask"
 

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -31,8 +31,6 @@
 		/obj/item/stock_parts/manipulator = 5,
 		)
 	refill_canister = /obj/item/vending_refill/engineering
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
 	light_mask = "engi-light-mask"
 

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -27,8 +27,6 @@
 		/obj/item/storage/box/smart_metal_foam = 1,
 	)
 	refill_canister = /obj/item/vending_refill/engivend
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
 	light_mask = "engivend-light-mask"
 

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -89,8 +89,6 @@
 		/obj/item/melee/skateboard/hoverboard = 1,
 	)
 	refill_canister = /obj/item/vending_refill/games
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND * 1.25
 	payment_department = ACCOUNT_SRV
 	light_mask = "games-light-mask"
 

--- a/code/modules/vending/liberation.dm
+++ b/code/modules/vending/liberation.dm
@@ -35,7 +35,7 @@
 	) //U S A
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = PAYCHECK_COMMAND * 2.5
-	extra_price = PAYCHECK_COMMAND * 2.5
+	default_price = 1000
+	extra_price = 1750
 	payment_department = ACCOUNT_SEC
 	light_mask = "liberation-light-mask"

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -30,7 +30,7 @@
 	armor = list(MELEE = 100, BULLET = 100, LASER = 100, ENERGY = 100, BOMB = 0, BIO = 0, FIRE = 100, ACID = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/donksoft
-	default_price = PAYCHECK_COMMAND
-	extra_price = PAYCHECK_COMMAND
+	default_price = 250
+	extra_price = 250
 	payment_department = ACCOUNT_SRV
 	light_mask = "donksoft-light-mask"

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -33,8 +33,6 @@
 		/obj/item/storage/organbox = 1,
 	)
 	refill_canister = /obj/item/vending_refill/medical
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_MED
 	light_mask = "med-light-mask"
 
@@ -81,8 +79,6 @@
 		/obj/item/reagent_containers/medigel/synthflesh = 2,
 		/obj/item/storage/pill_bottle/psicodine = 2,
 		)
-	default_price = 50
-	extra_price = 100
 	payment_department = ACCOUNT_MED
 	refill_canister = /obj/item/vending_refill/drugs
 

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -22,8 +22,6 @@
 		/obj/item/storage/box/gum/happiness = 1,
 	)
 	refill_canister = /obj/item/vending_refill/wallmed
-	default_price = PAYCHECK_COMMAND //Double the medical price due to being meant for public consumption, not player specfic
-	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_MED
 	tiltable = FALSE
 	light_mask = "wallmed-light-mask"

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -71,8 +71,6 @@
 		/obj/item/reagent_containers/spray/waterflower = 1,
 	)
 	refill_canister = /obj/item/vending_refill/hydroseeds
-	default_price = PAYCHECK_LOWER
-	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/hydroseeds

--- a/code/modules/vending/modularpc.dm
+++ b/code/modules/vending/modularpc.dm
@@ -16,8 +16,8 @@
 		/obj/item/pai_card = 2,
 	)
 	refill_canister = /obj/item/vending_refill/modularpc
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND
+	default_price = 25
+	extra_price = 50
 	payment_department = ACCOUNT_SCI
 
 /obj/item/vending_refill/modularpc

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -24,8 +24,6 @@
 		/obj/item/reagent_containers/cup/bottle/diethylamine = 5,
 	)
 	refill_canister = /obj/item/vending_refill/hydronutrients
-	default_price = PAYCHECK_CREW * 0.8
-	extra_price = PAYCHECK_COMMAND * 0.8
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/hydronutrients

--- a/code/modules/vending/plasmaresearch.dm
+++ b/code/modules/vending/plasmaresearch.dm
@@ -13,6 +13,4 @@
 		/obj/item/transfer_valve = 6,
 	)
 	contraband = list(/obj/item/assembly/health = 3)
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SCI

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -25,7 +25,6 @@
 		/obj/item/crowbar = 5,
 	)
 	refill_canister = /obj/item/vending_refill/robotics
-	default_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SCI
 
 /obj/item/vending_refill/robotics

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -31,8 +31,6 @@
 		/obj/item/watertank/pepperspray = 2,
 	)
 	refill_canister = /obj/item/vending_refill/security
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_SEC
 
 /obj/machinery/vending/security/pre_throw(obj/item/I)

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -36,8 +36,8 @@
 	)
 	refill_canister = /obj/item/vending_refill/snack
 	canload_access_list = list(ACCESS_KITCHEN)
-	default_price = PAYCHECK_CREW * 0.6
-	extra_price = PAYCHECK_CREW
+	default_price = 25
+	extra_price = 75
 	payment_department = ACCOUNT_SRV
 	input_display_header = "Chef's Food Selection"
 

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -13,8 +13,6 @@
 	)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/sovietsoda
-	default_price = 1
-	extra_price = PAYCHECK_CREW //One credit for every state of FREEDOM
 	payment_department = NO_FREEBIES
 	light_color = COLOR_PALE_ORANGE
 

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -22,8 +22,6 @@
 	)
 
 	refill_canister = /obj/item/vending_refill/sustenance
-	default_price = PAYCHECK_LOWER
-	extra_price = PAYCHECK_LOWER * 0.6
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/sustenance

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -27,8 +27,6 @@
 		/obj/item/dualsaber/toy = 5,
 	)
 	refill_canister = /obj/item/vending_refill/donksoft
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/donksoft

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -2,8 +2,6 @@
 	icon_state = "refill_clothes"
 
 /obj/machinery/vending/wardrobe
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND
 	payment_department = NO_FREEBIES
 	input_display_header = "Returned Clothing"
 	panel_type = "panel19"
@@ -194,7 +192,6 @@
 		/obj/item/organ/internal/tongue/robot = 2,
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
-	extra_price = PAYCHECK_COMMAND * 1.2
 	payment_department = ACCOUNT_SCI
 /obj/item/vending_refill/wardrobe/robo_wardrobe
 	machine_name = "RoboDrobe"
@@ -314,7 +311,6 @@
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/bar_wardrobe
 	payment_department = ACCOUNT_SRV
-	extra_price = PAYCHECK_COMMAND
 /obj/item/vending_refill/wardrobe/bar_wardrobe
 	machine_name = "BarDrobe"
 
@@ -374,8 +370,6 @@
 		/obj/item/plunger = 2,
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND * 0.8
 	payment_department = ACCOUNT_SRV
 	light_color = COLOR_STRONG_MAGENTA
 
@@ -566,7 +560,6 @@
 		/obj/item/clothing/head/flatcap = 1,
 		)
 	refill_canister = /obj/item/vending_refill/wardrobe/det_wardrobe
-	extra_price = PAYCHECK_COMMAND * 1.75
 	payment_department = ACCOUNT_SEC
 
 /obj/item/vending_refill/wardrobe/det_wardrobe

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -30,8 +30,6 @@
 		/obj/item/clothing/gloves/color/yellow = 1,
 	)
 	refill_canister = /obj/item/vending_refill/youtool
-	default_price = PAYCHECK_CREW
-	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
 
 /obj/item/vending_refill/youtool


### PR DESCRIPTION

## About The Pull Request
Vending machines now dispense items for free, barring a few exceptions:
snack vendors, cigarette vendors, booze vendors, and a few outliers.

Several restock units have had their cargo prices adjusted accordingly.
## Why It's Good For The Game
punishing players for doing their job is nonsense. additional charges on a personal basis for restock units that are already paid for is nonsense.
## Changelog
:cl:
del: lathe and techfab taxes. vendors are now free
del: commented out many custom_price and custom_premium_price instances
balance: cargo listings for vendor restock units have had their prices adjusted
/:cl:
