### PR TITLE
Slowdown + move delay adjustments

### DIFF
--- a/code/modules/clothing/shoes/clown.dm
+++ b/code/modules/clothing/shoes/clown.dm
@@ -3,7 +3,7 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	inhand_icon_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	var/enabled_waddle = TRUE
 	///List of possible sounds for the squeak component to use, allows for different clown shoe subtypes to have different sounds.
 	var/list/squeak_sound = list('sound/effects/clownstep1.ogg'=1,'sound/effects/clownstep2.ogg'=1)

--- a/code/modules/clothing/shoes/galoshes.dm
+++ b/code/modules/clothing/shoes/galoshes.dm
@@ -4,7 +4,7 @@
 	icon_state = "galoshes"
 	inhand_icon_state = "galoshes"
 	clothing_flags = NOSLIP
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	strip_delay = 30
 	equip_delay_other = 50
 	resistance_flags = NONE

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -5,7 +5,7 @@
 	inhand_icon_state = "magboots"
 	var/magboot_state = "magboots"
 	var/magpulse = FALSE
-	var/slowdown_active = 2
+	var/slowdown_active = 0.5
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 90, FIRE = 0, ACID = 0)
 	actions_types = list(/datum/action/item_action/toggle)
 	strip_delay = 70
@@ -71,3 +71,4 @@
 	name = "blood-red magboots"
 	icon_state = "syndiemag0"
 	magboot_state = "syndiemag"
+	slowdown_active = SHOES_SLOWDOWN

--- a/code/modules/clothing/shoes/wheelys.dm
+++ b/code/modules/clothing/shoes/wheelys.dm
@@ -66,7 +66,7 @@
 	greyscale_colors = null
 	greyscale_config = null
 	worn_icon_state = "rollerskates"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	wheels = /obj/vehicle/ridden/scooter/skateboard/wheelys/rollerskates
 	//custom_premium_price = PAYCHECK_CREW * 5
 	//custom_price = PAYCHECK_CREW * 5
@@ -79,7 +79,7 @@
 	greyscale_colors = null
 	greyscale_config = null
 	worn_icon_state = "skishoes"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN+0.5
 	wheels = /obj/vehicle/ridden/scooter/skateboard/wheelys/skishoes
 	//custom_premium_price = PAYCHECK_CREW * 1.6
 	//custom_price = PAYCHECK_CREW * 1.6

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -39,9 +39,9 @@
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
-		/obj/item/tank/jetpack/oxygen/captain,
+		/obj/item/tank/jetpack,
 		)
-	slowdown = 1
+	slowdown = 0.5
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 70)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -39,7 +39,7 @@
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
-		/obj/item/tank/jetpack,
+		/obj/item/tank/jetpack/oxygen/captain,
 		)
 	slowdown = 0.5
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 70)

--- a/code/modules/clothing/spacesuits/pirate.dm
+++ b/code/modules/clothing/spacesuits/pirate.dm
@@ -17,7 +17,6 @@
 	icon_state = "spacepirate"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/cup/glass/bottle/rum)
-	slowdown = 0
 	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 60, ACID = 75)
 	strip_delay = 40
 	equip_delay_other = 20

--- a/code/modules/clothing/spacesuits/softsuit.dm
+++ b/code/modules/clothing/spacesuits/softsuit.dm
@@ -22,7 +22,6 @@
 	icon_state = "void"
 	inhand_icon_state = null
 	desc = "A CentCom engineering dark red space suit. Age has degraded the suit making it difficult to move around in."
-	slowdown = 4
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/multitool)
 
 	//EVA suit
@@ -74,7 +73,6 @@
 	var/torn = FALSE
 	icon_state = "syndicate-orange"
 	inhand_icon_state = "syndicate-orange"
-	slowdown = 2
 	armor = list(MELEE = 5, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	strip_delay = 65
 

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -145,7 +145,6 @@
 /obj/item/clothing/suit/space/syndicate/contract
 	name = "contractor space suit"
 	desc = "A specialised black and gold space suit that's quicker, and more compact than its standard Syndicate counterpart. Can be ultra-compressed into even the tightest of spaces."
-	slowdown = 1
 	w_class = WEIGHT_CLASS_SMALL
 	icon_state = "syndicate-contract"
 	inhand_icon_state = null

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -27,7 +27,7 @@
 		/obj/item/fireaxe/metal_h2_axe,
 		/obj/item/tank/internals,
 	)
-	slowdown = 1
+	slowdown = 0.5
 	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 20, BOMB = 20, BIO = 50, FIRE = 100, ACID = 50)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
@@ -53,7 +53,7 @@
 	desc = "An old, bulky thermal protection suit."
 	icon_state = "thermal"
 	inhand_icon_state = "ro_suit"
-	slowdown = 1.5
+	slowdown = 0.5
 
 /obj/item/clothing/suit/utility/fire/atmos
 	name = "firesuit"
@@ -90,7 +90,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	slowdown = 2
+	slowdown = 0.5
 	armor = list(MELEE = 20, BULLET = 0, LASER = 20,ENERGY = 30, BOMB = 100, BIO = 50, FIRE = 80, ACID = 50)
 	flags_inv = HIDEJUMPSUIT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -151,7 +151,7 @@
 		/obj/item/geiger_counter,
 		/obj/item/tank/internals,
 		)
-	slowdown = 1.5
+	slowdown = 0.5
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 60, FIRE = 30, ACID = 30)
 	strip_delay = 60
 	equip_delay_other = 60

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -34,7 +34,7 @@ COMMENDATION_PERCENT_POLL 0.05
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
 RUN_DELAY 1.5
-WALK_DELAY 4
+WALK_DELAY 2
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.


### PR DESCRIPTION

## About The Pull Request
Most common sources of slowdown have been reduced to 0.5.
WALK_DELAY has been changed from 4 to 2, making it 0.5 slower than running.

I would've introduced more nuance to the numbers but it seems whenever movement smoothing isn't operating in multiples of 0.5 it creates some severely undesirable visuals.
## Why It's Good For The Game
Many pieces of equipment are completely impractical because of the severity of their slowdown. Magboots, utility suits and spacesuits should now be much less uncomfortable to use.
## Changelog
:cl:
balance: mass slowdown rebalancing
config: WALK_DELAY changed from 4 to 2
/:cl:
