### PR TITLE
Jetpack rebalance

### DIFF
--- a/code/datums/actions/items/boot_dash.dm
+++ b/code/datums/actions/items/boot_dash.dm
@@ -8,3 +8,11 @@
 /datum/action/item_action/bhop/brocket
 	name = "Activate Rocket Boots"
 	desc = "Activates the boot's rocket propulsion system, allowing the user to hurl themselves great distances."
+
+// scoundrel content
+
+/datum/action/item_action/jetboost
+	name = "Activate Jetpack Boost"
+	desc = "Activates the jetpack's ion propulsor, launching the user in zero gravity. Costs a negligible sum of power from the pack's internal cell, but takes a few seconds to accumulate ions after boosting."
+	icon_icon = 'icons/mob/actions/actions_mecha.dmi'
+	button_icon_state = "mech_overload_off"

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -7,11 +7,12 @@
 	righthand_file = 'icons/mob/inhands/equipment/jetpacks_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	distribute_pressure = ONE_ATMOSPHERE * O2STANDARD
+	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 	actions_types = list(/datum/action/item_action/set_internals, /datum/action/item_action/toggle_jetpack, /datum/action/item_action/jetpack_stabilization)
 	var/gas_type = /datum/gas/oxygen
 	var/on = FALSE
 	var/stabilizers = FALSE
-	var/full_speed = TRUE // If the jetpack will have a speedboost in space/nograv or not
+	var/full_speed = FALSE // If the jetpack will have a speedboost in space/nograv or not
 	var/datum/callback/get_mover
 	var/datum/callback/check_on_move
 
@@ -134,21 +135,9 @@
 	desc = "A jetpack made from two air tanks, a fire extinguisher and some atmospherics equipment. It doesn't look like it can hold much."
 	icon_state = "jetpack-improvised"
 	inhand_icon_state = "jetpack-improvised"
-	worn_icon = null
 	worn_icon_state = "jetpack-improvised"
-	volume = 20 //normal jetpacks have 70 volume
+	volume = 35 //normal jetpacks have 70 volume
 	gas_type = null //it starts empty
-	full_speed = FALSE //moves at modsuit jetpack speeds
-
-/obj/item/tank/jetpack/improvised/allow_thrust(num)
-	var/mob/user = get_user()
-	if(!user)
-		return FALSE
-	if(rand(0,250) == 0)
-		to_chat(user, span_notice("You feel your jetpack's engines cut out."))
-		turn_off(user)
-		return
-	return ..()
 
 /obj/item/tank/jetpack/void
 	name = "void jetpack (oxygen)"
@@ -179,7 +168,6 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	volume = 90
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //steal objective items are hard to destroy.
-	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
 /obj/item/tank/jetpack/oxygen/security
 	name = "security jetpack (oxygen)"

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -140,20 +140,20 @@
 	gas_type = null //it starts empty
 
 /obj/item/tank/jetpack/void
-	name = "void jetpack (oxygen)"
-	desc = "It works well in a void."
+	name = "void jetpack"
+	desc = "It works well in a void. It has an oxygen label on the tank."
 	icon_state = "jetpack-void"
 	inhand_icon_state = "jetpack-void"
 
 /obj/item/tank/jetpack/oxygen
-	name = "jetpack (oxygen)"
-	desc = "A tank of compressed oxygen for use as propulsion in zero-gravity areas. Use with caution."
+	name = "jetpack"
+	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution. It has an oxygen label on the tank."
 	icon_state = "jetpack"
 	inhand_icon_state = "jetpack"
 
 /obj/item/tank/jetpack/oxygen/harness
-	name = "jet harness (oxygen)"
-	desc = "A lightweight tactical harness, used by those who don't want to be weighed down by traditional jetpacks."
+	name = "jet harness"
+	desc = "A lightweight tactical harness, used by those who don't want to be weighed down by traditional jetpacks. It has an oxygen label on the tank."
 	icon_state = "jetpack-mini"
 	inhand_icon_state = "jetpack-black"
 	volume = 40
@@ -162,7 +162,7 @@
 
 /obj/item/tank/jetpack/oxygen/captain
 	name = "captain's jetpack"
-	desc = "A compact, lightweight jetpack containing a high amount of compressed oxygen."
+	desc = "A compact, lightweight jetpack containing a high amount of compressed gas. It has an oxygen label on the tank."
 	icon_state = "jetpack-captain"
 	inhand_icon_state = "jetpack-captain"
 	w_class = WEIGHT_CLASS_NORMAL
@@ -170,16 +170,16 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //steal objective items are hard to destroy.
 
 /obj/item/tank/jetpack/oxygen/security
-	name = "security jetpack (oxygen)"
-	desc = "A tank of compressed oxygen for use as propulsion in zero-gravity areas by security forces."
+	name = "red jetpack"
+	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution. It has an oxygen label on the tank."
 	icon_state = "jetpack-sec"
 	inhand_icon_state = "jetpack-sec"
 
 
 
 /obj/item/tank/jetpack/carbondioxide
-	name = "jetpack (carbon dioxide)"
-	desc = "A tank of compressed carbon dioxide for use as propulsion in zero-gravity areas. Painted black to indicate that it should not be used as a source for internals."
+	name = "black jetpack"
+	desc = "A tank of compressed gas for use as propulsion in zero-gravity areas. Use with caution. It has a carbon dioxide label on the tank."
 	icon_state = "jetpack-black"
 	inhand_icon_state = "jetpack-black"
 	distribute_pressure = 0

--- a/code/modules/clothing/spacesuits/_spacesuits.dm
+++ b/code/modules/clothing/spacesuits/_spacesuits.dm
@@ -39,7 +39,7 @@
 	allowed = list(
 		/obj/item/flashlight,
 		/obj/item/tank/internals,
-		/obj/item/tank/jetpack/oxygen/captain,
+		/obj/item/tank/jetpack,
 		)
 	slowdown = 1
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 80, ACID = 70)


### PR DESCRIPTION

## About The Pull Request
All jetpacks can now be equipped in the suit storage slot. Everything pathed from the basic spacesuit can now equip any jetpack.
All jetpacks have had their speed bonus removed. Exceptions to this might be established later down the line.
The makeshift jetpack has had its' capacity increased and the chance to fail removed.

An advanced jetpack has been added with the added feature of a jump-boost that only works in zero gravity, for space exploration. Needs to be mapped in and added to cargo.
## Why It's Good For The Game
Jetpacks are simultaneously too fast and underrepresented in gameplay outside of mostly undesirable niches.
## Changelog
:cl:
add: advanced jetpack
add: several jetpack names and descriptions
add: any jetpack can now be attached to spacesuits
balance: jetpacks no longer come with a speedboost by default
/:cl:
