### PR TITLE
Bombcap Config Adjustment

### DIFF
--- a/code/modules/uplink/uplink_items/explosive.dm
+++ b/code/modules/uplink/uplink_items/explosive.dm
@@ -82,9 +82,9 @@
 			in addition to dealing high amounts of damage to nearby personnel."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/grenade/syndieminibomb
-	cost = 6
+	cost = 3
 	purchasable_from = ~UPLINK_CLOWN_OPS
-
+	limited_stock = 2
 
 /datum/uplink_item/explosives/syndicate_bomb/emp
 	name = "Syndicate EMP Bomb"
@@ -110,7 +110,8 @@
 		The bomb core can be pried out and manually detonated with other explosives."
 	progression_minimum = 40 MINUTES
 	item = /obj/item/sbeacondrop/bomb
-	cost = 11
+	cost = 5
+	limited_stock = 1
 
 /datum/uplink_item/explosives/syndicate_bomb/New()
 	. = ..()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -452,9 +452,9 @@ REACTIONARY_EXPLOSIONS
 ## Can be any number above 4, some examples are provided below.
 
 ## Small (3, 7, 14)
-#BOMBCAP 14
+BOMBCAP 14
 ## Default (5, 10, 20) (recommended if you enable REACTIONARY_EXPLOSIONS above)
-BOMBCAP 20
+#BOMBCAP 20
 ## LagHell (7, 14, 28)
 #BOMBCAP 28
 


### PR DESCRIPTION
## About The Pull Request
Lowers the default bombcap to 14, down from 20.
To compensate, syndicate bombs now cost only 5 tc (from 11) and have a limited stock of 1.
Additionally, minibombs now cost only 3 tc and have a limited stock of 2.
## Why It's Good For The Game
The station will generally be much smaller, which the current bombcap isn't really appropriate for. I don't want bombs to be useless either, so a compromise had to be made there.
## Changelog
:cl:
balance: syndicate bomb tc cost 11 > 5, limited stock of 1
balance: minibomb tc cost 6 > 3, limited stock of 2
config: bombcap 20 > 14
/:cl:
