### PR TITLE
Faster crate climbing & drag slowdown adjustment

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -6,7 +6,7 @@
 	icon = 'icons/obj/storage/closet.dmi'
 	icon_state = "generic"
 	density = TRUE
-	drag_slowdown = 1.5 // Same as a prone mob
+	drag_slowdown = 0.5 // Same as walk_delay
 	max_integrity = 200
 	integrity_failure = 0.25
 	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 10, BIO = 0, FIRE = 70, ACID = 60)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -14,12 +14,12 @@
 	close_sound = 'sound/machines/crate_close.ogg'
 	open_sound_volume = 35
 	close_sound_volume = 50
-	drag_slowdown = 0
 	door_anim_time = 0 // no animation
 	pass_flags_self = PASSSTRUCTURE | LETPASSTHROW
 	var/crate_climb_time = 20
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
 
+/* scoundrel content - enable this if you want crate-specific climbing stats
 /obj/structure/closet/crate/Initialize(mapload)
 	. = ..()
 	if(icon_state == "[initial(icon_state)]open")
@@ -28,6 +28,14 @@
 	else
 		AddElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
 	update_appearance()
+*/
+
+// remove this if you want crate-specific climbing stats
+/obj/structure/closet/crate/Initialize(mapload)
+	. = ..()
+		AddElement(/datum/element/climbable)
+	update_appearance()
+//
 
 /obj/structure/closet/crate/Destroy()
 	QDEL_NULL(manifest)
@@ -65,6 +73,7 @@
 	if(manifest)
 		tear_manifest(user)
 
+/* scoundrel content - Enable this if you want crate-specific climbing stats
 /obj/structure/closet/crate/after_open(mob/living/user, force)
 	. = ..()
 	RemoveElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
@@ -74,7 +83,7 @@
 	. = ..()
 	RemoveElement(/datum/element/climbable, climb_time = crate_climb_time * 0.5, climb_stun = 0)
 	AddElement(/datum/element/climbable, climb_time = crate_climb_time, climb_stun = 0)
-
+*/
 
 /obj/structure/closet/crate/open(mob/living/user, force = FALSE)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Crate climbing now operates on the same numbers as tables and railings.
Additionally, both lockers and crates have been given a drag slowdown of 0.5. Crates are now no longer effortless to drag and lockers no longer tremendously slow you down.
## Why It's Good For The Game
## Changelog
:cl:
balance: crates are now quicker to climb
balance: crate and closets now share a slowdown of 0.5
code: some crate code commented out
/:cl:
