### PR TITLE
Accurate damage labels

### DIFF
--- a/code/datums/elements/weapon_description.dm
+++ b/code/datums/elements/weapon_description.dm
@@ -1,4 +1,5 @@
 #define HITS_TO_CRIT(damage) round(100 / damage, 0.1)
+#define FORCE_DESCRIPTIVE(damage) round(damage) //hijacking this define for flat damage readouts
 /**
  *
  * The purpose of this element is to widely provide the ability to examine an object and determine its stats, with the ability to add
@@ -44,7 +45,7 @@
 	SIGNAL_HANDLER
 
 	if(item.force >= 5 || item.throwforce >= 5 || item.override_notes || item.offensive_notes || attached_proc) /// Only show this tag for items that could feasibly be weapons, shields, or those that have special notes
-		examine_texts += span_notice("It appears to have an ever-updating bluespace <a href='?src=[REF(item)];examine=1'>warning label.</a>")
+		examine_texts += span_notice("This looks like it could be used as a weapon. <a href='?src=[REF(item)];examine=1'>Take a closer look.</a>")
 
 /**
  *
@@ -77,22 +78,22 @@
 	var/list/readout = list("") // Readout is used to store the text block output to the user so it all can be sent in one message
 
 	// Meaningless flavor text. The number of crimes is constantly changing because of the complex Nanotrasen legal system and the esoteric nature of time itself!
-	readout += "[span_warning("WARNING:")] This item has been marked as dangerous by the NT legal team because of its use in [span_warning("[rand(2,99)] [crimes[rand(1, crimes.len)]]")] in the past hour.\n"
+	readout += "Upon closer inspection, you think you've got a good idea of what this thing can do.\n"
 
 	// Doesn't show the base notes for items that have the override notes variable set to true
 	if(!source.override_notes)
 		// Make sure not to divide by 0 on accident
 		if(source.force > 0)
-			readout += "Our extensive research has shown that it takes a mere [span_warning("[HITS_TO_CRIT(source.force)] hit\s")] to beat down [victims[rand(1, victims.len)]] with no armor."
+			readout += "It looks like it'll do [span_warning("[FORCE_DESCRIPTIVE(source.force)] [source.damtype] force")] when swung and take [span_warning("[HITS_TO_CRIT(source.force)]")] hits to beat someone down."
 		else
-			readout += "Our extensive research found that you couldn't beat anyone to death with this if you tried."
+			readout += "Swinging this, you couldn't hurt someone with this if you tried."
 
 		if(source.throwforce > 0)
-			readout += "If you decide to throw this object instead, one will take [span_warning("[HITS_TO_CRIT(source.throwforce)] hit\s")] before collapsing."
+			readout += "It seems like it would do [span_warning("[FORCE_DESCRIPTIVE(source.throwforce)] [source.damtype] force")] when thrown and take [span_warning("[HITS_TO_CRIT(source.throwforce)]")] hits to knock someone someone over."
 		else
-			readout += "If you decide to throw this object instead, then you will have trouble damaging anything."
+			readout += "Throwing this, you probably couldn't do any damage at all."
 		if(source.armour_penetration > 0 || source.block_chance > 0)
-			readout += "This item has proven itself [span_warning("[weapon_tag_convert(source.armour_penetration)]")] of piercing armor and [span_warning("[weapon_tag_convert(source.block_chance)]")] of blocking attacks."
+			readout += "It looks like it could pierce [span_warning("[source.armour_penetration]%")] of armor and block [span_warning("[source.block_chance]%")] of attacks."
 	// Custom manual notes
 	if(source.offensive_notes)
 		readout += source.offensive_notes

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -72,7 +72,7 @@
 	var/list/readout = list()
 	// No dividing by 0
 	if(initial(exam_proj.damage) > 0)
-		readout += "Most monkeys our legal team subjected to these [span_warning(caliber)] rounds succumbed to their wounds after [span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * pellets)] shot\s")] at point-blank, taking [span_warning("[pellets] shot\s")] per round"
+		readout += "[span_warning("[FORCE_DESCRIPTIVE(initial(exam_proj.damage) * (pellets))] [initial(exam_proj.damage_type)] force")] with [span_warning("[(caliber)]")] ammunition, taking about [span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * (pellets))] [initial(exam_proj.armor_flag)]")] shots to [initial(exam_proj.damage_type) == STAMINA ? "down" : "critically injure"] someone, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)]")]."
 	if(initial(exam_proj.stamina) > 0)
 		readout += "[!readout.len ? "Most monkeys" : "More fortunate monkeys"] collapsed from exhaustion after [span_warning("[HITS_TO_CRIT(initial(exam_proj.stamina) * pellets)] impact\s")] of these [span_warning("[caliber]")] rounds"
 	if(!readout.len) // Everything else failed, give generic text

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -51,8 +51,8 @@
 	var/list/readout = list()
 
 	if(caliber && max_ammo) // Text references a 'magazine' as only magazines generally have the caliber variable initialized
-		readout += "Up to [span_warning("[max_ammo] [caliber] rounds")] can be found within this magazine. \
-		\nAccidentally discharging any of these projectiles may void your insurance contract."
+		readout += "Up to [span_warning("[max_ammo] [caliber] rounds")] can be found within this magazine."
+		readout += "As a loaded projectile weapon, you get the impression this could do..."
 
 	var/obj/item/ammo_casing/mag_ammo = get_round(TRUE)
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -98,16 +98,16 @@
 		return
 	var/obj/projectile/exam_proj
 	readout += "\nStandard models of this projectile weapon have [span_warning("[ammo_type.len] mode\s")]"
-	readout += "Our heroic interns have shown that one can theoretically stay standing after..."
+	readout += "As a projectile weapon, it looks like it could do..."
 	for(var/obj/item/ammo_casing/energy/for_ammo as anything in ammo_type)
 		exam_proj = for_ammo.projectile_type
 		if(!ispath(exam_proj))
 			continue
 
 		if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
-			readout += "[span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from [initial(exam_proj.damage_type) == STAMINA ? "immense pain" : "their wounds"]."
+			readout += "[span_warning("[FORCE_DESCRIPTIVE(initial(exam_proj.damage) * for_ammo.pellets)] [initial(exam_proj.damage_type)] force")] on [span_warning("[for_ammo.select_name]")] mode, taking about [span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * for_ammo.pellets)] [initial(exam_proj.armor_flag)]")] shots to [initial(exam_proj.damage_type) == STAMINA ? "down" : "critically injure"] someone, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)]")]."
 			if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
-				readout += "[span_warning("[HITS_TO_CRIT(initial(exam_proj.stamina) * for_ammo.pellets)] shot\s")] on [span_warning("[for_ammo.select_name]")] mode before collapsing from immense pain."
+				readout += "[span_warning("[FORCE_DESCRIPTIVE(initial(exam_proj.stamina) * for_ammo.pellets)] stamina force")] on [span_warning("[for_ammo.select_name]")] mode."
 		else
 			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
 


### PR DESCRIPTION

## About The Pull Request
Changes the 'bluespace labels' to provide more accurate information pertaining to the utility of an item as a weapon, providing direct damage numbers, armor penetration and damage types.

![f81650456dce6e7be2ce59a1c39e38e2](https://user-images.githubusercontent.com/67772722/206317818-635f11a3-053b-4623-9743-62d00e2a1f96.png)
## Why It's Good For The Game
Gatekeeping this information helps no one, and having it readily available and unobfuscated to all players will be strictly beneficial to both the experience of playing and the design-development process.
## Changelog
:cl:
code: changes to the damage labels
/:cl:
