### PR TITLE
Duffelbag & storage balance and more

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -8,11 +8,11 @@
 /// Standard backpacks can carry tiny, small & normal items, (e.g. fire extinguisher, stun baton, gas mask, metal sheets)
 #define WEIGHT_CLASS_NORMAL 3
 /// Items that can be weilded or equipped but not stored in an inventory, (e.g. defibrillator, backpack, space suits)
-#define WEIGHT_CLASS_BULKY 4
+#define WEIGHT_CLASS_BULKY 10
 /// Usually represents objects that require two hands to operate, (e.g. shotgun, two-handed melee weapons)
-#define WEIGHT_CLASS_HUGE 5
+#define WEIGHT_CLASS_HUGE 11
 /// Essentially means it cannot be picked up or placed in an inventory, (e.g. mech parts, safe)
-#define WEIGHT_CLASS_GIGANTIC 6
+#define WEIGHT_CLASS_GIGANTIC 12
 
 //Inventory depth: limits how many nested storage items you can access directly.
 //1: stuff in mob, 2: stuff in backpack, 3: stuff in box in backpack, etc

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1182,7 +1182,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		if(WEIGHT_CLASS_GIGANTIC)
 			. = "gigantic"
 		else
-			. = ""
+			. = "[span_warning("ERROR: UNDEFINED WEIGHT CLASS -- Report this to a coder")]"
 
 /// Removes all non-alphanumerics from the text, keep in mind this can lead to id conflicts
 /proc/sanitize_css_class_name(name)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -7,7 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/bombs_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/bombs_righthand.dmi'
 	desc = "Regulates the transfer of air between two tanks."
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_HUGE
 
 	var/obj/item/tank/tank_one
 	var/obj/item/tank/tank_two

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -23,6 +23,13 @@
 	resistance_flags = NONE
 	max_integrity = 300
 
+	attack_verb_continuous = list("smacks", "beats", "clubs")
+	attack_verb_simple = list("smack", "beat", "club")
+	force = 12
+	throwforce = 12
+	damtype = STAMINA
+	hitsound = 'sound/items/pillow_hit.ogg'
+
 /obj/item/storage/backpack/Initialize(mapload)
 	. = ..()
 	create_storage(max_slots = 21, max_total_storage = 21)
@@ -344,14 +351,15 @@
 
 /obj/item/storage/backpack/duffelbag
 	name = "duffel bag"
-	desc = "A large duffel bag for holding extra things."
+	desc = "A large duffel bag for holding extra things. You could stash some bulky items in this."
 	icon_state = "duffel"
 	inhand_icon_state = "duffel"
-	slowdown = 1
+	slowdown = 0.5
 
 /obj/item/storage/backpack/duffelbag/Initialize(mapload)
 	. = ..()
 	atom_storage.max_total_storage = 30
+	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/backpack/duffelbag/cursed
 	name = "living duffel bag"


### PR DESCRIPTION

## About The Pull Request
Duffelbags can now hold bulky items and have a slowdown of 0.5
Bulky items have had their weight value raised from 4 > 10
TTVs are now huge items (cannot be stored in duffelbags)

All backpack subtypes are now usable as a stamina-damage melee weapon, dealing 12 force per swing or throw.
## Why It's Good For The Game
Duffelbags kinda suck so i've given them a few considerable buffs. Also, more unconventional weaponry -- everyone has a weapon.
## Changelog
:cl:
add: stamina attacks to all backpack subtypes
add: error message for undefined weight classes
balance: duffelbag speed 1 > 0.5
balance: duffelbags can hold bulky items
balance: bulky storage value 4 > 10
balance: TTVs are now Huge items
/:cl:
