### PR TITLE
Stamina behavior changes

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -538,7 +538,8 @@
 
 /mob/living/carbon/update_stamina()
 	var/stam = getStaminaLoss()
-	if(stam > DAMAGE_PRECISION && (maxHealth - stam) <= crit_threshold)
+	var/harddam = getBruteLoss() + getFireLoss() // remove or change this line to 0 to remove hard damage consideration for stamcrit
+	if(stam > DAMAGE_PRECISION && (maxHealth - (stam + harddam)) <= crit_threshold)
 		if (!stat)
 			enter_stamcrit()
 	else if(HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -954,7 +954,7 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 		return
-	var/health_deficiency = max((maxHealth - health) + staminaloss)
+	var/health_deficiency = ((maxHealth - health) + staminaloss)
 	if(health_deficiency >= 40)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -954,7 +954,7 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 		return
-	var/health_deficiency = max((maxHealth - health), staminaloss)
+	var/health_deficiency = max((maxHealth - health) + staminaloss)
 	if(health_deficiency >= 40)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -368,7 +368,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	//DO NOT update health here, it'll be done in the carbon's life.
 	if(stamina_dam > DAMAGE_PRECISION && owner.stam_regen_start_time <= world.time)
-		heal_damage(0, 0, INFINITY, null, FALSE)
+		heal_damage(0, 0, 5, null, FALSE)
 		. |= BODYPART_LIFE_UPDATE_HEALTH
 
 //Applies brute and burn damage to the organ. Returns 1 if the damage-icon states changed at all.


### PR DESCRIPTION
## About The Pull Request
Stamina now regenerates slowly after the 10 second delay, rather than instantly recovering.
Stamcrit and slowdowns can now be caused by a combination of stamina damage and hard damage types.
If something mysteriously breaks pertaining to damage slowdown, this is probably the PR you're looking for.

The stamina readout's code has not been adjusted to account for this. I'm not touching that code; we'll replace it with something better eventually.
## Why It's Good For The Game
Stamina damage in low numbers isn't very useful due to how forgiving the instant regeneration can be. This is a problem because we want stamina to be a larger part of the game.
Furthermore, game heavily encourages you to use either a full stamina loadout or a full damage loadout due to the fact that mixing damage doesn't have any real benefit. We'd like things to be more dynamic.
## Changelog
:cl:
balance: stamina now regenerates slowly
code: stamcrit code
code: damage slowdown code
/:cl:
