### PR TITLE
Limb damage rebalance

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2154,9 +2154,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 				ADD_TRAIT(src, TRAIT_IMMOBILIZED, LACKING_LOCOMOTION_APPENDAGES_TRAIT)
 
 	if(usable_legs < default_num_legs)
-		var/limbless_slowdown = (default_num_legs - usable_legs) * 3
+		var/limbless_slowdown = (default_num_legs - usable_legs) * 1
 		if(!usable_legs && usable_hands < default_num_hands)
-			limbless_slowdown += (default_num_hands - usable_hands) * 3
+			limbless_slowdown += (default_num_hands - usable_hands) * 1
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/limbless, multiplicative_slowdown = limbless_slowdown)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/limbless)

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -64,7 +64,7 @@
 	///Multiplier of the limb's damage that gets applied to the mob
 	var/body_damage_coeff = 1
 	///Multiplier of the limb's stamina damage that gets applied to the mob. Why is this 0.75 by default? Good question!
-	var/stam_damage_coeff = 0.75
+	var/stam_damage_coeff = 1
 	var/brutestate = 0
 	var/burnstate = 0
 	///The current amount of brute damage the limb has

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -80,7 +80,7 @@
 	max_damage = 50
 	max_stamina_damage = 50
 	aux_layer = HANDS_PART_LAYER
-	body_damage_coeff = 0.75
+	body_damage_coeff = 1
 	can_be_disabled = TRUE
 	unarmed_attack_verb = "punch" /// The classic punch, wonderfully classic and completely random
 	unarmed_damage_low = 1
@@ -298,7 +298,7 @@
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
 	max_damage = 50
-	body_damage_coeff = 0.75
+	body_damage_coeff = 1
 	max_stamina_damage = 50
 	can_be_disabled = TRUE
 	unarmed_attack_effect = ATTACK_EFFECT_KICK


### PR DESCRIPTION

## About The Pull Request
Changes the limb damage coefficients from 0.75 to 1, meaning 100% of the damage will be contributed toward the body's damage count.
Also changes the slowdown when a leg is disabled/removed from 3 to 1.
## Why It's Good For The Game
Makes the utility of limb targeting more consistent and reasonable
## Changelog
:cl:
balance: limb damage coeffs 0.75 > 1
balance: leg removal slowdown 3 > 1
/:cl:
