### PR TITLE
suppressor balance

### DIFF
--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -401,15 +401,15 @@
 ///Installs a new suppressor, assumes that the suppressor is already in the contents of src
 /obj/item/gun/ballistic/proc/install_suppressor(obj/item/suppressor/S)
 	suppressed = S
-	w_class += S.w_class //so pistols do not fit in pockets when suppressed
+//	w_class += S.w_class //so pistols do not fit in pockets when suppressed
 	update_appearance()
 
 /obj/item/gun/ballistic/clear_suppressor()
 	if(!can_unsuppress)
 		return
 	if(isitem(suppressed))
-		var/obj/item/I = suppressed
-		w_class -= I.w_class
+/*		var/obj/item/I = suppressed
+		w_class -= I.w_class*/
 	return ..()
 
 /obj/item/gun/ballistic/AltClick(mob/user)

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -39,11 +39,13 @@
 
 /datum/uplink_item/stealthy_weapons/suppressor
 	name = "Suppressor"
-	desc = "This suppressor will silence the shots of the weapon it is attached to for increased stealth and superior ambushing capability. It is compatible with many small ballistic guns including the Makarov, Stechkin APS and C-20r, but not revolvers or energy guns."
+	desc = "A clandestine suppressor suited to a variety of weapons. It looks badass, but most operatives agree, they're nigh-completely useless in the tight corridors of a spacestation."
 	item = /obj/item/suppressor
-	cost = 3
+	cost = 0
+	limited_stock = 2
 	surplus = 10
 	purchasable_from = ~UPLINK_CLOWN_OPS
+	illegal_tech = FALSE
 
 /datum/uplink_item/stealthy_weapons/holster
 	name = "Syndicate Holster"


### PR DESCRIPTION

## About The Pull Request
Suppressors now no longer contribute to the weight class of an item, and are free in the uplink at limited stock
## Why It's Good For The Game
in their current state they literally wouldn't be worth using even if they were free
## Changelog
:cl:
balance: suppressor does not contribute to weight class
balance: suppressor is free in the uplink
/:cl:
