### PR TITLE
Cyberform name update and config changes

### DIFF
--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -12,7 +12,7 @@
 	var/group
 
 	/// Whether or not to allow numbers in the person's name
-	var/allow_numbers = FALSE
+	var/allow_numbers = TRUE
 
 	/// If the highest priority job matches this, will prioritize this name in the UI
 	var/relevant_job

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -167,7 +167,7 @@ DISABLE_SECBORG
 
 ## How long the delay is before the Away Mission gate opens. Default is half an hour.
 ## 600 is one minute.
-GATEWAY_DELAY 18000
+#GATEWAY_DELAY 9000
 
 ## The probability of the gateway mission being a config one
 CONFIG_GATEWAY_CHANCE 0
@@ -423,7 +423,7 @@ MORGUE_CADAVER_OTHER_SPECIES_PROBABILITY 50
 
 
 ##Overflow job. Default is assistant
-OVERFLOW_JOB Assistant
+OVERFLOW_JOB Greenhand
 
 ## Overflow slot cap. Set to -1 for unlimited. If limited, it will still open up if every other job is full.
 OVERFLOW_CAP -1

--- a/scoundrel/code/modules/mob/living/carbon/human/species_types/scoundrel_android.dm
+++ b/scoundrel/code/modules/mob/living/carbon/human/species_types/scoundrel_android.dm
@@ -59,11 +59,9 @@
 /datum/species/scoundrel_android/random_name(gender,unique,lastname)
 	
 	var/new_name
-	var/new_last_name
 	var/randname
 	new_name = pick(GLOB.posibrain_names)
-	new_last_name = pick(GLOB.posibrain_names)
-	randname = "[new_name]-[new_last_name]"
+	randname = "[new_name]-[rand(100, 999)]"
 
 	return randname
 


### PR DESCRIPTION

## About The Pull Request
numbers can now be used in names in the pref screen, the overflow job is now set to greenhand, and gateway delay
## Why It's Good For The Game
## Changelog
:cl:
config: minor config changes
code: numbers can now be used in names in preferences
/:cl:
