### PR TITLE
bulky medkits

### DIFF
--- a/code/modules/jobs/job_types/scoundrel_jobs.dm
+++ b/code/modules/jobs/job_types/scoundrel_jobs.dm
@@ -160,7 +160,7 @@
 	l_hand = /obj/item/storage/medkit/surgery
 	mask = /obj/item/clothing/mask/surgical
 //	l_pocket = 
-	r_pocket = /obj/item/storage/pouch/chemistry/preloaded/medical
+	r_pocket = /obj/item/storage/pouch/medical/preloaded/advanced
 
 	chameleon_extras = /obj/item/stamp/cmo
 

--- a/scoundrel/code/game/objects/items/storage/medkit.dm
+++ b/scoundrel/code/game/objects/items/storage/medkit.dm
@@ -1,0 +1,665 @@
+/* First aid storage
+ * Contains:
+ * First Aid Kits
+ * Pill Bottles
+ * Dice Pack (in a pill bottle)
+ */
+
+/*
+ * First Aid Kits
+ */
+/obj/item/storage/medkit
+	name = "medkit"
+	desc = "It's an emergency medical kit for those serious boo-boos."
+	icon_state = "medkit"
+	inhand_icon_state = "medkit"
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
+	force = 12
+	throwforce = 12
+	throw_speed = 3
+	throw_range = 7
+	demolition_mod = 1.25
+	wound_bonus = 5
+	w_class = WEIGHT_CLASS_BULKY
+
+	attack_verb_continuous = list("treats")
+	attack_verb_simple = list("treat")
+	hitsound = 'sound/weapons/smash.ogg'
+	drop_sound = 'sound/items/handling/toolbox_drop.ogg'
+	pickup_sound = 'sound/items/handling/toolbox_pickup.ogg'
+
+	var/empty = FALSE
+	var/damagetype_healed //defines damage type of the medkit. General ones stay null. Used for medibot healing bonuses
+
+/obj/item/storage/medkit/regular
+	icon_state = "medkit"
+	desc = "A first aid kit with the ability to heal common types of injuries."
+
+/obj/item/storage/medkit/regular/suicide_act(mob/living/carbon/user)
+	user.visible_message(span_suicide("[user] begins giving [user.p_them()]self aids with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return BRUTELOSS
+
+/obj/item/storage/medkit/regular/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/stack/medical/suture = 2,
+		/obj/item/stack/medical/mesh = 2,
+		/obj/item/reagent_containers/hypospray/medipen = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/emergency
+	icon_state = "medbriefcase"
+	name = "emergency medkit"
+	desc = "A very simple first aid kit meant to secure and stabilize serious wounds for later treatment."
+	w_class = WEIGHT_CLASS_NORMAL
+	force = 8
+	throwforce = 8
+
+/obj/item/storage/medkit/emergency/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/healthanalyzer/wound = 1,
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/stack/medical/suture/emergency = 1,
+		/obj/item/stack/medical/ointment = 1,
+		/obj/item/reagent_containers/hypospray/medipen/ekit = 2,
+		/obj/item/storage/pill_bottle/iron = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/surgery
+	name = "surgical medkit"
+	icon_state = "medkit_surgery"
+	inhand_icon_state = "medkit"
+	desc = "A high capacity aid kit for doctors, full of medical supplies and basic surgical equipment"
+	w_class = WEIGHT_CLASS_NORMAL
+	force = 10
+	throwforce = 10
+
+/obj/item/storage/medkit/surgery/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL //holds the same equipment as a medibelt
+	atom_storage.max_slots = 12
+	atom_storage.max_total_storage = 24
+	atom_storage.set_holdable(list(
+		/obj/item/healthanalyzer,
+		/obj/item/dnainjector,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/cup/beaker,
+		/obj/item/reagent_containers/cup/bottle,
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/medigel,
+		/obj/item/reagent_containers/spray,
+		/obj/item/lighter,
+		/obj/item/storage/fancy/cigarettes,
+		/obj/item/storage/pill_bottle,
+		/obj/item/stack/medical,
+		/obj/item/flashlight/pen,
+		/obj/item/extinguisher/mini,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/sensor_device,
+		/obj/item/radio,
+		/obj/item/clothing/gloves/,
+		/obj/item/lazarus_injector,
+		/obj/item/bikehorn/rubberducky,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/mask/breath,
+		/obj/item/clothing/mask/breath/medical,
+		/obj/item/surgical_drapes, //for true paramedics
+		/obj/item/scalpel,
+		/obj/item/circular_saw,
+		/obj/item/bonesetter,
+		/obj/item/surgicaldrill,
+		/obj/item/retractor,
+		/obj/item/cautery,
+		/obj/item/hemostat,
+		/obj/item/blood_filter,
+		/obj/item/shears,
+		/obj/item/geiger_counter,
+		/obj/item/clothing/neck/stethoscope,
+		/obj/item/stamp,
+		/obj/item/clothing/glasses,
+		/obj/item/wrench/medical,
+		/obj/item/clothing/mask/muzzle,
+		/obj/item/reagent_containers/blood,
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/gun/syringe/syndicate,
+		/obj/item/implantcase,
+		/obj/item/implant,
+		/obj/item/implanter,
+		/obj/item/pinpointer/crew,
+		/obj/item/holosign_creator/medical,
+		/obj/item/stack/sticky_tape //surgical tape
+		))
+
+/obj/item/storage/medkit/surgery/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/healthanalyzer = 1,
+		/obj/item/stack/medical/gauze/twelve = 1,
+		/obj/item/stack/medical/suture = 2,
+		/obj/item/stack/medical/mesh = 2,
+		/obj/item/reagent_containers/hypospray/medipen = 1,
+		/obj/item/surgical_drapes = 1,
+		/obj/item/scalpel = 1,
+		/obj/item/hemostat = 1,
+		/obj/item/cautery = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/ancient
+	icon_state = "oldfirstaid"
+	desc = "A first aid kit with the ability to heal common types of injuries."
+	w_class = WEIGHT_CLASS_NORMAL
+	force = 10
+	throwforce = 10
+
+/obj/item/storage/medkit/ancient/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/stack/medical/bruise_pack = 3,
+		/obj/item/stack/medical/ointment= 3)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/ancient/heirloom
+	desc = "A first aid kit with the ability to heal common types of injuries. You start thinking of the good old days just by looking at it."
+	empty = TRUE // long since been ransacked by hungry powergaming assistants breaking into med storage
+
+/obj/item/storage/medkit/fire
+	name = "burn treatment kit"
+	desc = "A specialized medical kit for when the ordnance lab <i>-spontaneously-</i> burns down."
+	icon_state = "medkit_burn"
+	inhand_icon_state = "medkit-ointment"
+	damagetype_healed = BURN
+
+/obj/item/storage/medkit/fire/suicide_act(mob/living/carbon/user)
+	user.visible_message(span_suicide("[user] begins rubbing \the [src] against [user.p_them()]self! It looks like [user.p_theyre()] trying to start a fire!"))
+	return FIRELOSS
+
+/obj/item/storage/medkit/fire/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/pill/patch/aiuri = 3,
+		/obj/item/reagent_containers/spray/hercuri = 1,
+		/obj/item/reagent_containers/hypospray/medipen/oxandrolone = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/toxin
+	name = "toxin treatment kit"
+	desc = "Used to treat toxic blood content and radiation poisoning."
+	icon_state = "medkit_toxin"
+	inhand_icon_state = "medkit-toxin"
+	damagetype_healed = TOX
+
+/obj/item/storage/medkit/toxin/suicide_act(mob/living/carbon/user)
+	user.visible_message(span_suicide("[user] begins licking the lead paint off \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return TOXLOSS
+
+
+/obj/item/storage/medkit/toxin/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+	    /obj/item/storage/pill_bottle/multiver/less = 1,
+		/obj/item/reagent_containers/syringe/syriniver = 3,
+		/obj/item/storage/pill_bottle/potassiodide = 1,
+		/obj/item/reagent_containers/hypospray/medipen/penacid = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/o2
+	name = "oxygen deprivation treatment kit"
+	desc = "A box full of oxygen goodies."
+	icon_state = "medkit_o2"
+	inhand_icon_state = "medkit-o2"
+	damagetype_healed = OXY
+
+/obj/item/storage/medkit/o2/suicide_act(mob/living/carbon/user)
+	user.visible_message(span_suicide("[user] begins hitting [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return OXYLOSS
+
+/obj/item/storage/medkit/o2/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/syringe/convermol = 3,
+		/obj/item/reagent_containers/hypospray/medipen/salbutamol = 1,
+		/obj/item/reagent_containers/hypospray/medipen = 1,
+		/obj/item/storage/pill_bottle/iron = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/brute
+	name = "brute trauma treatment kit"
+	desc = "A first aid kit for when you get toolboxed."
+	icon_state = "medkit_brute"
+	inhand_icon_state = "medkit-brute"
+	damagetype_healed = BRUTE
+
+/obj/item/storage/medkit/brute/suicide_act(mob/living/carbon/user)
+	user.visible_message(span_suicide("[user] begins beating [user.p_them()]self over the head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return BRUTELOSS
+
+/obj/item/storage/medkit/brute/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/pill/patch/libital = 3,
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/storage/pill_bottle/probital = 1,
+		/obj/item/reagent_containers/hypospray/medipen/salacid = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/advanced
+	name = "advanced first aid kit"
+	desc = "An advanced kit to help deal with advanced wounds."
+	icon_state = "medkit_advanced"
+	inhand_icon_state = "medkit-rad"
+	//custom_premium_price = PAYCHECK_COMMAND * 6
+	damagetype_healed = "all"
+
+/obj/item/storage/medkit/advanced/PopulateContents()
+	if(empty)
+		return
+	var/static/items_inside = list(
+		/obj/item/reagent_containers/pill/patch/synthflesh = 3,
+		/obj/item/reagent_containers/hypospray/medipen/atropine = 2,
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/storage/pill_bottle/penacid = 1)
+	generate_items_inside(items_inside,src)
+
+/obj/item/storage/medkit/tactical
+	name = "combat medical kit"
+	desc = "I hope you've got insurance."
+	icon_state = "medkit_tactical"
+	inhand_icon_state = "medkit-tactical"
+	damagetype_healed = "all"
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/medkit/tactical/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/medkit/tactical/PopulateContents()
+	if(empty)
+		return
+	new /obj/item/stack/medical/gauze(src)
+	new /obj/item/defibrillator/compact/combat/loaded(src)
+	new /obj/item/reagent_containers/hypospray/combat(src)
+	new /obj/item/reagent_containers/pill/patch/libital(src)
+	new /obj/item/reagent_containers/pill/patch/libital(src)
+	new /obj/item/reagent_containers/pill/patch/aiuri(src)
+	new /obj/item/reagent_containers/pill/patch/aiuri(src)
+	new /obj/item/clothing/glasses/hud/health/night(src)
+
+//medibot assembly
+/obj/item/storage/medkit/attackby(obj/item/bodypart/bodypart, mob/user, params)
+	if((!istype(bodypart, /obj/item/bodypart/arm/left/robot)) && (!istype(bodypart, /obj/item/bodypart/arm/right/robot)))
+		return ..()
+
+	//Making a medibot!
+	if(contents.len >= 1)
+		balloon_alert(user, "items inside!")
+		return
+
+	var/obj/item/bot_assembly/medbot/medbot_assembly = new
+	if (istype(src, /obj/item/storage/medkit/fire))
+		medbot_assembly.set_skin("ointment")
+	else if (istype(src, /obj/item/storage/medkit/toxin))
+		medbot_assembly.set_skin("tox")
+	else if (istype(src, /obj/item/storage/medkit/o2))
+		medbot_assembly.set_skin("o2")
+	else if (istype(src, /obj/item/storage/medkit/brute))
+		medbot_assembly.set_skin("brute")
+	else if (istype(src, /obj/item/storage/medkit/advanced))
+		medbot_assembly.set_skin("advanced")
+	user.put_in_hands(medbot_assembly)
+	medbot_assembly.balloon_alert(user, "arm added")
+	medbot_assembly.robot_arm = bodypart.type
+	medbot_assembly.medkit_type = type
+	qdel(bodypart)
+	qdel(src)
+
+/*
+ * Pill Bottles
+ */
+
+/obj/item/storage/pill_bottle
+	name = "pill bottle"
+	desc = "It's an airtight container for storing medication."
+	icon_state = "pill_canister"
+	icon = 'icons/obj/medical/chemical.dmi'
+	inhand_icon_state = "contsolid"
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
+	w_class = WEIGHT_CLASS_SMALL
+
+/obj/item/storage/pill_bottle/Initialize(mapload)
+	. = ..()
+	atom_storage.allow_quick_gather = TRUE
+	atom_storage.set_holdable(list(/obj/item/reagent_containers/pill))
+
+/obj/item/storage/pill_bottle/suicide_act(mob/living/user)
+	user.visible_message(span_suicide("[user] is trying to get the cap off [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+	return TOXLOSS
+
+/obj/item/storage/pill_bottle/multiver
+	name = "bottle of multiver pills"
+	desc = "Contains pills used to counter toxins."
+
+/obj/item/storage/pill_bottle/multiver/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/multiver(src)
+
+/obj/item/storage/pill_bottle/multiver/less
+
+/obj/item/storage/pill_bottle/multiver/less/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/pill/multiver(src)
+
+/obj/item/storage/pill_bottle/epinephrine
+	name = "bottle of epinephrine pills"
+	desc = "Contains pills used to stabilize patients."
+
+/obj/item/storage/pill_bottle/epinephrine/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/epinephrine(src)
+
+/obj/item/storage/pill_bottle/mutadone
+	name = "bottle of mutadone pills"
+	desc = "Contains pills used to treat genetic abnormalities."
+
+/obj/item/storage/pill_bottle/mutadone/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/mutadone(src)
+
+/obj/item/storage/pill_bottle/potassiodide
+	name = "bottle of potassium iodide pills"
+	desc = "Contains pills used to reduce radiation damage."
+
+/obj/item/storage/pill_bottle/potassiodide/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/pill/potassiodide(src)
+
+/obj/item/storage/pill_bottle/probital
+	name = "bottle of probital pills"
+	desc = "Contains pills used to treat brute damage. The tag in the bottle states 'Eat before ingesting, may cause fatigue'."
+
+/obj/item/storage/pill_bottle/probital/PopulateContents()
+	for(var/i in 1 to 4)
+		new /obj/item/reagent_containers/pill/probital(src)
+
+/obj/item/storage/pill_bottle/iron
+	name = "bottle of iron pills"
+	desc = "Contains pills used to reduce blood loss slowly. The tag in the bottle states 'Only take one each five minutes'."
+
+/obj/item/storage/pill_bottle/iron/PopulateContents()
+	for(var/i in 1 to 4)
+		new /obj/item/reagent_containers/pill/iron(src)
+
+/obj/item/storage/pill_bottle/mannitol
+	name = "bottle of mannitol pills"
+	desc = "Contains pills used to treat brain damage."
+
+/obj/item/storage/pill_bottle/mannitol/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/mannitol(src)
+
+//Contains 4 pills instead of 7, and 5u pills instead of 50u (50u pills heal 250 brain damage, 5u pills heal 25)
+/obj/item/storage/pill_bottle/mannitol/braintumor
+	desc = "Contains diluted pills used to treat brain tumor symptoms. Take one when feeling lightheaded."
+
+/obj/item/storage/pill_bottle/mannitol/braintumor/PopulateContents()
+	for(var/i in 1 to 4)
+		new /obj/item/reagent_containers/pill/mannitol/braintumor(src)
+
+/obj/item/storage/pill_bottle/stimulant
+	name = "bottle of stimulant pills"
+	desc = "Guaranteed to give you that extra burst of energy during a long shift!"
+
+/obj/item/storage/pill_bottle/stimulant/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/stimulant(src)
+
+/obj/item/storage/pill_bottle/mining
+	name = "bottle of patches"
+	desc = "Contains patches used to treat brute and burn damage."
+
+/obj/item/storage/pill_bottle/mining/PopulateContents()
+	new /obj/item/reagent_containers/pill/patch/aiuri(src)
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/pill/patch/libital(src)
+
+/obj/item/storage/pill_bottle/zoom
+	name = "suspicious pill bottle"
+	desc = "The label is pretty old and almost unreadable, you recognize some chemical compounds."
+
+/obj/item/storage/pill_bottle/zoom/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/zoom(src)
+
+/obj/item/storage/pill_bottle/happy
+	name = "suspicious pill bottle"
+	desc = "There is a smiley on the top."
+
+/obj/item/storage/pill_bottle/happy/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/happy(src)
+
+/obj/item/storage/pill_bottle/lsd
+	name = "suspicious pill bottle"
+	desc = "There is a crude drawing which could be either a mushroom, or a deformed moon."
+
+/obj/item/storage/pill_bottle/lsd/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/lsd(src)
+
+/obj/item/storage/pill_bottle/aranesp
+	name = "suspicious pill bottle"
+	desc = "The label has 'fuck disablers' hastily scrawled in black marker."
+
+/obj/item/storage/pill_bottle/aranesp/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/aranesp(src)
+
+/obj/item/storage/pill_bottle/psicodine
+	name = "bottle of psicodine pills"
+	desc = "Contains pills used to treat mental distress and traumas."
+
+/obj/item/storage/pill_bottle/psicodine/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/psicodine(src)
+
+/obj/item/storage/pill_bottle/penacid
+	name = "bottle of pentetic acid pills"
+	desc = "Contains pills to expunge radiation and toxins."
+
+/obj/item/storage/pill_bottle/penacid/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/pill/penacid(src)
+
+
+/obj/item/storage/pill_bottle/neurine
+	name = "bottle of neurine pills"
+	desc = "Contains pills to treat non-severe mental traumas."
+
+/obj/item/storage/pill_bottle/neurine/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/neurine(src)
+
+/obj/item/storage/pill_bottle/maintenance_pill
+	name = "bottle of maintenance pills"
+	desc = "An old pill bottle. It smells musty."
+
+/obj/item/storage/pill_bottle/maintenance_pill/Initialize(mapload)
+	. = ..()
+	var/obj/item/reagent_containers/pill/P = locate() in src
+	name = "bottle of [P.name]s"
+
+/obj/item/storage/pill_bottle/maintenance_pill/PopulateContents()
+	for(var/i in 1 to rand(1,7))
+		new /obj/item/reagent_containers/pill/maintenance(src)
+
+/obj/item/storage/pill_bottle/maintenance_pill/full/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/pill/maintenance(src)
+
+///////////////////////////////////////// Psychologist inventory pillbottles
+/obj/item/storage/pill_bottle/happinesspsych
+	name = "happiness pills"
+	desc = "Contains pills used as a last resort means to temporarily stabilize depression and anxiety. WARNING: side effects may include slurred speech, drooling, and severe addiction."
+
+/obj/item/storage/pill_bottle/happinesspsych/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/happinesspsych(src)
+
+/obj/item/storage/pill_bottle/lsdpsych
+	name = "mindbreaker toxin pills"
+	desc = "!FOR THERAPEUTIC USE ONLY! Contains pills used to alleviate the symptoms of Reality Dissociation Syndrome."
+
+/obj/item/storage/pill_bottle/lsdpsych/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/lsdpsych(src)
+
+/obj/item/storage/pill_bottle/paxpsych
+	name = "pax pills"
+	desc = "Contains pills used to temporarily pacify patients that are deemed a harm to themselves or others."
+
+/obj/item/storage/pill_bottle/paxpsych/PopulateContents()
+	for(var/i in 1 to 5)
+		new /obj/item/reagent_containers/pill/paxpsych(src)
+
+/obj/item/storage/organbox
+	name = "organ transport box"
+	desc = "An advanced box with an cooling mechanism that uses cryostylane or other cold reagents to keep the organs or bodyparts inside preserved."
+	icon_state = "organbox"
+	base_icon_state = "organbox"
+	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
+	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
+	throw_speed = 3
+	throw_range = 7
+	//custom_premium_price = PAYCHECK_CREW * 4
+	/// var to prevent it freezing the same things over and over
+	var/cooling = FALSE
+
+/obj/item/storage/organbox/Initialize(mapload)
+	. = ..()
+
+	create_storage(type = /datum/storage/organ_box, max_specific_storage = WEIGHT_CLASS_BULKY, max_total_storage = 21)
+	atom_storage.set_holdable(list(
+		/obj/item/organ,
+		/obj/item/bodypart,
+		/obj/item/food/icecream
+		))
+
+	create_reagents(100, TRANSPARENT)
+	START_PROCESSING(SSobj, src)
+
+/obj/item/storage/organbox/process(delta_time)
+	///if there is enough coolant var
+	var/cool = FALSE
+	var/amount = min(reagents.get_reagent_amount(/datum/reagent/cryostylane), 0.05 * delta_time)
+	if(amount > 0)
+		reagents.remove_reagent(/datum/reagent/cryostylane, amount)
+		cool = TRUE
+	else
+		amount = min(reagents.get_reagent_amount(/datum/reagent/consumable/ice), 0.1 * delta_time)
+		if(amount > 0)
+			reagents.remove_reagent(/datum/reagent/consumable/ice, amount)
+			cool = TRUE
+	if(!cooling && cool)
+		cooling = TRUE
+		update_appearance()
+		for(var/C in contents)
+			freeze_contents(C)
+		return
+	if(cooling && !cool)
+		cooling = FALSE
+		update_appearance()
+		for(var/C in contents)
+			unfreeze_contents(C)
+
+/obj/item/storage/organbox/update_icon_state()
+	icon_state = "[base_icon_state][cooling ? "-working" : null]"
+	return ..()
+
+///freezes the organ and loops bodyparts like heads
+/obj/item/storage/organbox/proc/freeze_contents(datum/source, obj/item/I)
+	SIGNAL_HANDLER
+	if(isinternalorgan(I))
+		var/obj/item/organ/internal/int_organ = I
+		int_organ.organ_flags |= ORGAN_FROZEN
+		return
+	if(isbodypart(I))
+		var/obj/item/bodypart/B = I
+		for(var/obj/item/organ/internal/int_organ in B.contents)
+			int_organ.organ_flags |= ORGAN_FROZEN
+
+///unfreezes the organ and loops bodyparts like heads
+/obj/item/storage/organbox/proc/unfreeze_contents(datum/source, obj/item/I)
+	SIGNAL_HANDLER
+	if(isinternalorgan(I))
+		var/obj/item/organ/internal/int_organ = I
+		int_organ.organ_flags &= ~ORGAN_FROZEN
+		return
+	if(isbodypart(I))
+		var/obj/item/bodypart/B = I
+		for(var/obj/item/organ/internal/int_organ in B.contents)
+			int_organ.organ_flags &= ~ORGAN_FROZEN
+
+/obj/item/storage/organbox/attackby(obj/item/I, mob/user, params)
+	if(is_reagent_container(I) && I.is_open_container())
+		var/obj/item/reagent_containers/RC = I
+		var/units = RC.reagents.trans_to(src, RC.amount_per_transfer_from_this, transfered_by = user)
+		if(units)
+			balloon_alert(user, "[units]u transferred")
+			return
+	if(istype(I, /obj/item/plunger))
+		balloon_alert(user, "plunging...")
+		if(do_after(user, 10, target = src))
+			balloon_alert(user, "plunged")
+			reagents.clear_reagents()
+		return
+	return ..()
+
+/obj/item/storage/organbox/suicide_act(mob/living/carbon/user)
+	if(HAS_TRAIT(user, TRAIT_RESISTCOLD)) //if they're immune to cold, just do the box suicide
+		var/obj/item/bodypart/head/myhead = user.get_bodypart(BODY_ZONE_HEAD)
+		if(myhead)
+			user.visible_message(span_suicide("[user] puts [user.p_their()] head into \the [src] and begins closing it! It looks like [user.p_theyre()] trying to commit suicide!"))
+			myhead.dismember()
+			myhead.forceMove(src) //force your enemies to kill themselves with your head collection box!
+			playsound(user, "desecration-01.ogg", 50, TRUE, -1)
+			return BRUTELOSS
+		user.visible_message(span_suicide("[user] is beating [user.p_them()]self with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
+		return BRUTELOSS
+	user.visible_message(span_suicide("[user] is putting [user.p_their()] head inside the [src], it looks like [user.p_theyre()] trying to commit suicide!"))
+	user.adjust_bodytemperature(-300)
+	user.apply_status_effect(/datum/status_effect/freon)
+	return FIRELOSS
+
+// wall mounted
+
+/obj/item/storage/medkit/wall
+	icon_state = "medkit_wall"
+	name = "first aid box"
+	desc = "A box for storing first-aid supplies, mounted to the wall."
+	w_class = WEIGHT_CLASS_GIGANTIC
+	anchored = 1
+	can_be_unanchored = 0
+	max_integrity = 50
+
+/obj/item/storage/medkit/regular/wall
+	icon_state = "medkit_wall"
+	name = "first aid box"
+	desc = "A box for storing first-aid supplies, mounted to the wall."
+	w_class = WEIGHT_CLASS_GIGANTIC
+	anchored = 1
+	can_be_unanchored = 0
+	max_integrity = 50

--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -67,12 +67,22 @@
 	new /obj/item/reagent_containers/dropper(src)
 	new /obj/item/reagent_containers/syringe(src)
 
-/obj/item/storage/pouch/chemistry/medical
+//medical
+/obj/item/storage/pouch/medical
 	name = "medical pouch"
 	icon_state = "medical"
-/obj/item/storage/pouch/chemistry/preloaded/medical
-	name = "medical pouch"
-	icon_state = "medical"
+
+/obj/item/storage/pouch/medical/preloaded
+
+/obj/item/storage/pouch/medical/preloaded/PopulateContents()
+	new /obj/item/stack/medical/suture(src)
+	new /obj/item/stack/medical/mesh(src)
+	new /obj/item/reagent_containers/hypospray/medipen(src)
+
+/obj/item/storage/pouch/medical/preloaded/advanced/PopulateContents()
+	new /obj/item/reagent_containers/pill/patch/synthflesh(src)
+	new /obj/item/reagent_containers/hypospray/medipen/penacid(src)
+	new /obj/item/reagent_containers/hypospray/medipen/atropine(src)
 
 //forensic
 /obj/item/storage/pouch/forensic

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1874,7 +1874,7 @@
 #include "code\game\objects\items\storage\garment.dm"
 #include "code\game\objects\items\storage\holsters.dm"
 #include "code\game\objects\items\storage\lockbox.dm"
-#include "code\game\objects\items\storage\medkit.dm"
+#include "scoundrel\code\game\objects\items\storage\medkit.dm"
 #include "code\game\objects\items\storage\secure.dm"
 #include "code\game\objects\items\storage\sixpack.dm"
 #include "code\game\objects\items\storage\storage.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
most medkits have been made bulky and given force values & sounds
also changes the medical pouch

additionally, medkits are now overridden in the modular folder
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes hoarding and/or stealing valuable medicine less convenient
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: medical pouch is no longer a subtype of chemistry pouch
balance: medkits are now usually bulky and can deal damage
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
