### PR TITLE
Command comms access

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -95,13 +95,13 @@
 /obj/machinery/computer/communications/proc/authenticated_as_non_silicon_captain(mob/user)
 	if (issilicon(user))
 		return FALSE
-	return ACCESS_CAPTAIN in authorize_access
+	return ACCESS_COMMAND in authorize_access
 
 /// Are we a silicon, OR we're logged in as the captain?
 /obj/machinery/computer/communications/proc/authenticated_as_silicon_or_captain(mob/user)
 	if (issilicon(user))
 		return TRUE
-	return ACCESS_CAPTAIN in authorize_access
+	return ACCESS_COMMAND in authorize_access
 
 /// Are we a silicon, OR logged in?
 /obj/machinery/computer/communications/proc/authenticated(mob/user)
@@ -190,7 +190,7 @@
 					to_chat(usr, span_warning("You need to swipe your ID!"))
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 					return
-				if (!(ACCESS_CAPTAIN in id_card.access))
+				if (!(ACCESS_COMMAND in id_card.access))
 					to_chat(usr, span_warning("You are not authorized to do this!"))
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 					return


### PR DESCRIPTION

## About The Pull Request
Any command role can now full access the comms console.

As a side effect, the detective can now also fully access the comms console. Maybe this should be changed down the line.
## Why It's Good For The Game
the QM should have the same mechanical leverages as the captain.
## Changelog
:cl:
balance: the comms console can be fully accessed with only command access now
/:cl:
