### PR TITLE
Science funds to cargo budget

### DIFF
--- a/code/modules/research/ordnance/_scipaper.dm
+++ b/code/modules/research/ordnance/_scipaper.dm
@@ -122,7 +122,7 @@
 	techweb_to_publish.published_papers[experiment_path][tier] = src
 	techweb_to_publish.scientific_cooperation[partner_path] += gains[SCIPAPER_COOPERATION_INDEX]
 	if(istype(techweb_to_publish, /datum/techweb/science))
-		var/datum/bank_account/dept_budget = SSeconomy.get_dep_account(ACCOUNT_SCI)
+		var/datum/bank_account/dept_budget = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		if(dept_budget)
 			dept_budget.adjust_money(gains[SCIPAPER_FUNDING_INDEX] * SCIPAPER_GAIN_TO_MONEY)
 

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -330,7 +330,7 @@
 		add_design_by_id(id)
 	update_node_status(node)
 	if(get_that_dosh)
-		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_SCI)
+		var/datum/bank_account/science_department_bank_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
 		science_department_bank_account?.adjust_money(SSeconomy.techweb_bounty)
 		log_message += ", gaining [SSeconomy.techweb_bounty] to [science_department_bank_account] for it."
 	log_research(log_message)


### PR DESCRIPTION

## About The Pull Request
Funds obtained through science should now go directly to the cargo budget.
## Why It's Good For The Game
The science budget is entirely inaccessible by design, so the station funds should go through the one budget card that does exist.
## Changelog
:cl:
add: funds acquired through science should now go directly to the cargo budget
/:cl:
