### PR TITLE
Medkit health analyzers + more fixes

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -40,7 +40,7 @@
 	return BRUTELOSS
 
 /obj/item/healthanalyzer/attack_self(mob/user)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src, reading_check_flags = (READING_CHECK_LITERACY)) || user.is_blind())
 		return
 
 	scanmode = (scanmode + 1) % SCANMODE_COUNT
@@ -82,7 +82,7 @@
 	add_fingerprint(user)
 
 /obj/item/healthanalyzer/attack_secondary(mob/living/victim, mob/living/user, params)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src, reading_check_flags = (READING_CHECK_LITERACY)) || user.is_blind())
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	chemscan(user, victim)
@@ -442,7 +442,7 @@
 /obj/item/healthanalyzer/AltClick(mob/user)
 	..()
 
-	if(!user.canUseTopic(src, be_close = TRUE) || !user.can_read(src) || user.is_blind())
+	if(!user.canUseTopic(src, be_close = TRUE) || !user.can_read(src, reading_check_flags = (READING_CHECK_LITERACY)) || user.is_blind())
 		return
 
 	mode = !mode
@@ -505,7 +505,7 @@
 			L.dropItemToGround(src)
 
 /obj/item/healthanalyzer/wound/attack(mob/living/carbon/patient, mob/living/carbon/human/user)
-	if(!user.can_read(src) || user.is_blind())
+	if(!user.can_read(src, reading_check_flags = (READING_CHECK_LITERACY)) || user.is_blind())
 		return
 
 	add_fingerprint(user)

--- a/scoundrel/code/game/objects/items/storage/medkit.dm
+++ b/scoundrel/code/game/objects/items/storage/medkit.dm
@@ -47,7 +47,8 @@
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/stack/medical/suture = 2,
 		/obj/item/stack/medical/mesh = 2,
-		/obj/item/reagent_containers/hypospray/medipen = 1)
+		/obj/item/reagent_containers/hypospray/medipen = 1,
+		/obj/item/healthanalyzer = 1,)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/medkit/emergency


### PR DESCRIPTION

## About The Pull Request
In https://github.com/ScoundrelOutpost/ScoundrelOutpost/pull/92 I fixed an issue with health analyzers, but neglected to resolve all instances of that issue. This PR expands on that, and also adds health analyzers to the standard medkit.
## Why It's Good For The Game
Applying scarcity to health analyzers doesn't work to any meaningful effect except being a nuisance to players.
## Changelog
:cl:
add: health analyzers have been returned to standard medkits
fix: analyzers can now, definitely be used in the dark
/:cl:
