### PR TITLE
9mm Pistol Tweaks

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -1,9 +1,10 @@
 /obj/item/gun/ballistic/automatic/pistol
-	name = "\improper Makarov pistol"
-	desc = "A small, easily concealable 9mm handgun. Has a threaded barrel for suppressors."
-	icon_state = "pistol"
+	name = "agent pistol"
+	desc = "An easily concealed, clandestine 9mm handgun. Has a threaded barrel for suppressors."
+	icon_state = "pistol_evil"
 	w_class = WEIGHT_CLASS_SMALL
 	mag_type = /obj/item/ammo_box/magazine/m9mm
+	empty_indicator = TRUE
 	can_suppress = TRUE
 	burst_size = 1
 	fire_delay = 0

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -22,12 +22,11 @@
 // Low progression cost
 
 /datum/uplink_item/dangerous/pistol
-	name = "Makarov Pistol"
-	desc = "A small, easily concealable handgun that uses 9mm auto rounds in 8-round magazines and is compatible \
-			with suppressors."
-	progression_minimum = 10 MINUTES
+	name = "Agent Pistol"
+	desc = "An easily concealed, clandestine handgun that uses 9mm auto rounds in 8-round magazines. Has a \
+			threaded barrel for suppressors."
 	item = /obj/item/gun/ballistic/automatic/pistol
-	cost = 7
+	cost = 5
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/dangerous/throwingweapons


### PR DESCRIPTION

## About The Pull Request
Changed the 9mm makarov to use the black pistol sprite and reflavors it as the agent pistol.
## Why It's Good For The Game
## Changelog
:cl:
add: the makarov is now called the agent pistol and uses the black pistol sprite
balance: agent pistol pistol now costs 5 tc from the uplink
/:cl:
