### PR TITLE
Starsuit tweaks

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -10,9 +10,9 @@
 	equip_sound = 'sound/items/equip/jumpsuit_equip.ogg'
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
-	limb_integrity = 30
+	limb_integrity = 300
 	/// The variable containing the flags for how the woman uniform cropping is supposed to interact with the sprite.
-	var/female_sprite_flags = FEMALE_UNIFORM_FULL
+	var/female_sprite_flags = NO_FEMALE_UNIFORM
 	var/has_sensor = HAS_SENSORS // For the crew computer
 	var/random_sensor = TRUE
 	var/sensor_mode = NO_SENSORS

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -17,7 +17,7 @@
 /obj/item/clothing/under/color/jumpskirt
 	body_parts_covered = CHEST|GROIN|ARMS
 	dying_key = DYE_REGISTRY_JUMPSKIRT
-	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
+//	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	icon_state = "jumpskirt"
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 

--- a/scoundrel/code/modules/clothing/under/scoundrel_jumpsuits.dm
+++ b/scoundrel/code/modules/clothing/under/scoundrel_jumpsuits.dm
@@ -1,6 +1,7 @@
 /obj/item/clothing/under/starsuit
 	name = "starsuit"
-	desc = "A mobile, form-fitting EVA suit. Sleek and fashionable, but not particularly warming or durable. Don't forget to wear a jacket."
+	desc = "A mobile, form-fitting EVA suit. Sleek and fashionable, but not particularly warming or durable. Don't forget to wear a jacket.\n\
+	It can be worn as an undersuit or oversuit, but it doesn't have any vital tracking attached."
 	icon = 'scoundrel/icons/obj/clothing/scoundrel_under.dmi'
 	icon_state = "starsuit"
 	worn_icon = 'scoundrel/icons/mob/clothing/scoundrel_under.dmi'
@@ -21,14 +22,13 @@
 
 	strip_delay = 80
 	equip_delay_other = 80
-	limb_integrity = 60
+	limb_integrity = 30
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 100, WOUND = 0)
 	clothing_flags = STOPSPRESSUREDAMAGE
 	w_class = WEIGHT_CLASS_NORMAL
 //	slowdown = 0.5 need to figure out a better downside than this
 
-	has_sensor = LOCKED_SENSORS
-	sensor_mode = SENSOR_COORDS
+	has_sensor = NO_SENSORS
 	random_sensor = FALSE
 	can_adjust = FALSE
 
@@ -45,6 +45,7 @@
 	icon_state = "starsuit"
 	worn_icon = 'scoundrel/icons/mob/clothing/scoundrel_head.dmi'
 	worn_icon_state = "starsuit"
+	flash_protect = 0
 
 /obj/item/clothing/head/helmet/space/starsuit/engineer
 	name = "starsuit hardhat"


### PR DESCRIPTION

## About The Pull Request
Adjusts starsuits to have a lower limb durability.
Removes suit sensors from starsuits.
Removes flash protection from starsuits, which was never intentional.
Adjusts normal jumpsuits to have a higher limb durability.
Disables "female versions" for most standard jumpsuits.
## Why It's Good For The Game
## Changelog
:cl:
del: most jumpsuits no longer have a "female" worn variant
balance: standard jumpsuits have a much higher durability
balance: starsuits have a lower durability
balance: starsuits no longer have suit sensors
fix: starsuits no longer have flash protection
/:cl:
