### PR TITLE
Throwing Star Balance

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -366,8 +366,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/equipment/shields_righthand.dmi'
 	force = 2
 	throwforce = 10 //10 + 2 (WEIGHT_CLASS_SMALL) * 4 (EMBEDDED_IMPACT_PAIN_MULTIPLIER) = 18 damage on hit due to guaranteed embedding
-	throw_speed = 4
-	embedding = list("pain_mult" = 4, "embed_chance" = 100, "fall_chance" = 0)
+	throw_speed = 2
+	embedding = list(ignore_throwspeed_threshold = TRUE, "pain_mult" = 1, "embed_chance" = 100, "fall_chance" = 0)
 	armour_penetration = 40
 
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION

## About The Pull Request
Lowers the rng embed damage on throwing stars
## Why It's Good For The Game
In a bit of an oversight, I forgot to inspect the embed values on throwing stars. Prior to this change, they do 40 damage per pure rng embed proc. That's way too much.
## Changelog
:cl:
balance: lowered throwing star pain_mult from 4 to 1
/:cl:
