### PR TITLE
More embed balance

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -145,13 +145,13 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 
 //Embedded objects
 ///Chance for embedded objects to cause pain (damage user)
-#define EMBEDDED_PAIN_CHANCE 15
+#define EMBEDDED_PAIN_CHANCE 5
 ///Chance for embedded object to fall out (causing pain but removing the object)
 #define EMBEDDED_ITEM_FALLOUT 5
 ///Chance for an object to embed into somebody when thrown
 #define EMBED_CHANCE 45
 ///Coefficient of multiplication for the damage the item does while embedded (this*item.w_class)
-#define EMBEDDED_PAIN_MULTIPLIER 0.5
+#define EMBEDDED_PAIN_MULTIPLIER 0.2
 ///Coefficient of multiplication for the damage the item does when it first embeds (this*item.w_class)
 #define EMBEDDED_IMPACT_PAIN_MULTIPLIER 1
 ///The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
@@ -163,7 +163,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 ///Chance for embedded objects to cause pain every time they move (jostle)
 #define EMBEDDED_JOSTLE_CHANCE 5
 ///Coefficient of multiplication for the damage the item does while
-#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER 0.5
+#define EMBEDDED_JOSTLE_PAIN_MULTIPLIER 0.2
 ///This percentage of all pain will be dealt as stam damage rather than brute (0-1)
 #define EMBEDDED_PAIN_STAM_PCT 0.5
 ///For thrown weapons, every extra speed it's thrown at above its normal throwspeed will add this to the embed chance

--- a/code/datums/components/embedded.dm
+++ b/code/datums/components/embedded.dm
@@ -94,7 +94,7 @@
 		victim.throw_alert(ALERT_EMBEDDED_OBJECT, /atom/movable/screen/alert/embeddedobject)
 		playsound(victim,'sound/weapons/bladeslice.ogg', 40)
 		weapon.add_mob_blood(victim)//it embedded itself in you, of course it's bloody!
-		damage += weapon.w_class * impact_pain_mult
+		damage = weapon.throwforce * impact_pain_mult
 		victim.add_mood_event("embedded", /datum/mood_event/embedded)
 
 	if(damage > 0)
@@ -132,7 +132,7 @@
 	if(victim.stat == DEAD)
 		return
 
-	var/damage = weapon.w_class * pain_mult
+	var/damage = weapon.throwforce * pain_mult
 	var/pain_chance_current = DT_PROB_RATE(pain_chance / 100, delta_time) * 100
 	if(pain_stam_pct && HAS_TRAIT_FROM(victim, TRAIT_INCAPACITATED, STAMINA)) //if it's a less-lethal embed, give them a break if they're already stamcritted
 		pain_chance_current *= 0.2
@@ -166,7 +166,7 @@
 		chance *= 0.5
 
 	if(harmful && prob(chance))
-		var/damage = weapon.w_class * jostle_pain_mult
+		var/damage = weapon.throwforce * jostle_pain_mult
 		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, wound_bonus = CANT_WOUND)
 		to_chat(victim, span_userdanger("[weapon] embedded in your [limb.plaintext_zone] jostles and stings!"))
 
@@ -176,7 +176,7 @@
 	var/mob/living/carbon/victim = parent
 
 	if(harmful)
-		var/damage = weapon.w_class * remove_pain_mult
+		var/damage = weapon.throwforce * remove_pain_mult
 		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, wound_bonus = CANT_WOUND)
 
 	victim.visible_message(span_danger("[weapon] falls [harmful ? "out" : "off"] of [victim.name]'s [limb.plaintext_zone]!"), span_userdanger("[weapon] falls [harmful ? "out" : "off"] of your [limb.plaintext_zone]!"))
@@ -190,7 +190,7 @@
 	if(I != weapon || src.limb != limb)
 		return
 	var/mob/living/carbon/victim = parent
-	var/time_taken = rip_time * weapon.w_class
+	var/time_taken = rip_time
 	INVOKE_ASYNC(src, PROC_REF(complete_rip_out), victim, I, limb, time_taken)
 
 /// everything async that ripOut used to do
@@ -202,7 +202,7 @@
 		qdel(src)
 		return
 	if(harmful)
-		var/damage = weapon.w_class * remove_pain_mult
+		var/damage = weapon.throwforce * remove_pain_mult
 		limb.receive_damage(brute=(1-pain_stam_pct) * damage, stamina=pain_stam_pct * damage, sharpness=SHARP_EDGED) //It hurts to rip it out, get surgery you dingus. unlike the others, this CAN wound + increase slash bloodflow
 		victim.emote("scream")
 
@@ -271,7 +271,7 @@
 			vision_distance=COMBAT_MESSAGE_RANGE, ignored_mobs=victim)
 		to_chat(victim, span_userdanger("[user] begins plucking [weapon] from your [limb.plaintext_zone]..."))
 
-	var/pluck_time = 2.5 SECONDS * weapon.w_class * (self_pluck ? 2 : 1)
+	var/pluck_time = 2.5 SECONDS * (self_pluck ? 2 : 1)
 	if(!do_after(user, pluck_time, victim))
 		if(self_pluck)
 			to_chat(user, span_danger("You fail to pluck [weapon] from your [limb.plaintext_zone]."))


### PR DESCRIPTION
## About The Pull Request
Rewrites some of the embed math to utilize the throwforce rather than the weapon-in-question's weight class. Also makes some more adjustments to the multipliers.
## Why It's Good For The Game
I don't think I really have to elaborate on why embeds using storage sizes in their damage calculations is ridiculous.
## Changelog
:cl:
balance: rebalanced damage multiplier adjustments
code: embeds now use throwforce in the math for embed damage
/:cl:
