### PR TITLE
Damage & Armor Rebalance

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -311,3 +311,41 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define BATON_ATTACK_DONE 2
 /// The baton attack is still going. baton_effect() is called.
 #define BATON_ATTACKING 3
+
+//// ARMOR ////
+
+// No protections whatsoever
+#define TOTALLY_UNARMORED list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0, WOUND = 0)
+
+// Jumpsuits should never have considerable combat advantages
+#define GENERIC_JUMPSUIT_ARMOR list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 10, ACID = 0, WOUND = 0)
+
+// T1 ARMOR
+#define GENERIC_ARMOR_T1 list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 0, FIRE = 20, ACID = 0, WOUND = 5)
+
+// Hardhats get slightly better noncombat armor
+#define GENERIC_HARDHAT_ARMOR list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 100, ACID = 10, WOUND = 5)
+
+// Basic environmental protections, like labcoats
+#define GENERIC_ENV_ARMOR_T1 list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 60, FIRE = 60, ACID = 60, WOUND = 5)
+
+////
+
+// T2 ARMOR
+#define GENERIC_ARMOR_T2 list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
+
+// Sacrifices other defenses for improved melee armor
+#define GENERIC_ARMOR_MELEE list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
+
+// Sacrifices other defenses for improved bullet armor
+#define GENERIC_ARMOR_BULLET list(MELEE = 20, BULLET = 30, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
+
+// Sacrifices other defenses for improved energy armor
+#define GENERIC_ARMOR_ENERGY list(MELEE = 20, BULLET = 10, LASER = 30, ENERGY = 30, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
+
+////
+
+// T3 ARMOR
+#define GENERIC_ARMOR_T3 list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 50, BIO = 0, FIRE = 50, ACID = 50, WOUND = 15)
+// bio protected
+#define GENERIC_ARMOR_T3_SEALED list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 50, BIO = 100, FIRE = 50, ACID = 50, WOUND = 15)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -376,3 +376,8 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 // bio protected
 #define GENERIC_ARMOR_T3_SEALED list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 50, BIO = 100, FIRE = 50, ACID = 50, WOUND = 15)
 
+////
+
+// misc armor
+#define STARSUIT_ARMOR list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 70, FIRE = 70, ACID = 70, WOUND = 0)
+#define STARSUIT_HARDHAT_ARMOR list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 70, FIRE = 70, ACID = 70, WOUND = 5)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -318,7 +318,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define TOTALLY_UNARMORED list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0, WOUND = 0)
 
 // Jumpsuits should never have considerable combat advantages
-#define GENERIC_JUMPSUIT_ARMOR list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 10, ACID = 0, WOUND = 0)
+#define GENERIC_JUMPSUIT_ARMOR list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 10, ACID = 10, WOUND = 0)
 
 ////
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -333,6 +333,8 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 
 // T2 ARMOR
 #define GENERIC_ARMOR_T2 list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
+// bio protected
+#define GENERIC_ARMOR_T2_SEALED list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 100, FIRE = 50, ACID = 20, WOUND = 10)
 
 // Sacrifices other defenses for improved melee armor
 #define GENERIC_ARMOR_MELEE list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -320,20 +320,28 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 // Jumpsuits should never have considerable combat advantages
 #define GENERIC_JUMPSUIT_ARMOR list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 10, ACID = 0, WOUND = 0)
 
+////
+
 // T1 ARMOR
 #define GENERIC_ARMOR_T1 list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 0, FIRE = 20, ACID = 0, WOUND = 5)
+
+// bio protected
+#define GENERIC_ARMOR_T1_SEALED list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 30, BIO = 100, FIRE = 20, ACID = 0, WOUND = 5)
+
+// fire protected
+#define GENERIC_ARMOR_T1_FIRE list(MELEE = 10, BULLET = 10, LASER = 10,ENERGY = 10, BOMB = 30, BIO = 50, FIRE = 100, ACID = 50, WOUND = 5)
 
 // Hardhats get slightly better noncombat armor
 #define GENERIC_HARDHAT_ARMOR list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 100, ACID = 10, WOUND = 5)
 
-// Basic environmental protections, like labcoats
-#define GENERIC_ENV_ARMOR_T1 list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 60, FIRE = 60, ACID = 60, WOUND = 5)
+// Basic environmental protections, like jackets
+#define GENERIC_ENV_ARMOR_T1 list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 30, FIRE = 30, ACID = 30, WOUND = 5)
 
 // Bio
-#define GENERIC_ARMOR_BIO list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 30, ACID = 100)
+#define GENERIC_ARMOR_BIO list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 30, ACID = 100, WOUND = 5)
 
 // Actively detrimental T1
-#define GENERIC_ENV_ARMOR_VULNERABILITY_T1 list(MELEE = -20, BULLET = -20, LASER = -20, ENERGY = -20, BOMB = 0, BIO = 100, FIRE = 60, ACID = 75)
+#define GENERIC_ENV_ARMOR_VULNERABILITY_T1 list(MELEE = -10, BULLET = -10, LASER = -10, ENERGY = -10, BOMB = 0, BIO = 100, FIRE = 60, ACID = 75, WOUND = 0)
 
 ////
 
@@ -344,7 +352,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define GENERIC_ARMOR_T2_SEALED list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 100, FIRE = 50, ACID = 20, WOUND = 10)
 
 // fire protected
-#define GENERIC_ARMOR_T2_FIRE list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 50, FIRE = 100, ACID = 50)
+#define GENERIC_ARMOR_T2_FIRE list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 50, FIRE = 100, ACID = 50, WOUND = 10)
 
 // Sacrifices other defenses for improved melee armor
 #define GENERIC_ARMOR_MELEE list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
@@ -355,8 +363,11 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 // Sacrifices other defenses for improved energy armor
 #define GENERIC_ARMOR_ENERGY list(MELEE = 20, BULLET = 10, LASER = 30, ENERGY = 30, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
 
+// Advanced environmental protections, like labcoats
+#define GENERIC_ENV_ARMOR_T2 list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 60, FIRE = 60, ACID = 60, WOUND = 5)
+
 // Sacrifices other defenses to not gib from explosions
-#define GENERIC_ARMOR_BOMB list(MELEE = 10, BULLET = 10, LASER = 10,ENERGY = 10, BOMB = 100, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10))
+#define GENERIC_ARMOR_BOMB list(MELEE = 10, BULLET = 10, LASER = 10,ENERGY = 10, BOMB = 100, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
 
 ////
 

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -329,12 +329,22 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 // Basic environmental protections, like labcoats
 #define GENERIC_ENV_ARMOR_T1 list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 60, FIRE = 60, ACID = 60, WOUND = 5)
 
+// Bio
+#define GENERIC_ARMOR_BIO list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 30, ACID = 100)
+
+// Actively detrimental T1
+#define GENERIC_ENV_ARMOR_VULNERABILITY_T1 list(MELEE = -20, BULLET = -20, LASER = -20, ENERGY = -20, BOMB = 0, BIO = 100, FIRE = 60, ACID = 75)
+
 ////
 
 // T2 ARMOR
 #define GENERIC_ARMOR_T2 list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
+
 // bio protected
 #define GENERIC_ARMOR_T2_SEALED list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 100, FIRE = 50, ACID = 20, WOUND = 10)
+
+// fire protected
+#define GENERIC_ARMOR_T2_FIRE list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 50, FIRE = 100, ACID = 50)
 
 // Sacrifices other defenses for improved melee armor
 #define GENERIC_ARMOR_MELEE list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
@@ -345,9 +355,13 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 // Sacrifices other defenses for improved energy armor
 #define GENERIC_ARMOR_ENERGY list(MELEE = 20, BULLET = 10, LASER = 30, ENERGY = 30, BOMB = 40, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10)
 
+// Sacrifices other defenses to not gib from explosions
+#define GENERIC_ARMOR_BOMB list(MELEE = 10, BULLET = 10, LASER = 10,ENERGY = 10, BOMB = 100, BIO = 0, FIRE = 50, ACID = 20, WOUND = 10))
+
 ////
 
 // T3 ARMOR
 #define GENERIC_ARMOR_T3 list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 50, BIO = 0, FIRE = 50, ACID = 50, WOUND = 15)
 // bio protected
 #define GENERIC_ARMOR_T3_SEALED list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 50, BIO = 100, FIRE = 50, ACID = 50, WOUND = 15)
+

--- a/code/datums/components/shielded.dm
+++ b/code/datums/components/shielded.dm
@@ -24,13 +24,13 @@
 	/// Should the shield lose charges equal to the damage dealt by a hit?
 	var/lose_multiple_charges = FALSE
 	/// Attack types that cannot be blocked.
-	var/static/list/cannot_block_types = list()
+	var/list/cannot_block_types = list()
 	/// What type of damage our shield is weakagainst. If null, there are no weaknesses.
-	var/static/list/shield_weakness
+	var/list/shield_weakness
 	/// The multiplier for how many charges are lost from incoming damage if that damage matches our shield weakness type
 	var/shield_weakness_multiplier = 1
 	/// What type of damage our shield is strong against. If null, there are no strengths.
-	var/static/list/shield_resistance
+	var/list/shield_resistance
 	/// The multiplier for how many charges are lost from incoming damage if that damage matches our shield resistant type.
 	var/shield_resistance_multiplier = 1
 	/// Shield uses no overlay while active

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -16,22 +16,21 @@
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_SMALL
 	hitsound = SFX_SWING_HIT
-	armour_penetration = 35
+	armour_penetration = 50
 	light_system = MOVABLE_LIGHT
 	light_range = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 75
+	block_chance = 0
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF
-	wound_bonus = -10
 	bare_wound_bonus = 20
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/saber_color = "green"
-	var/two_hand_force = 34
+	var/two_hand_force = 25
 	var/hacked = FALSE
 	var/list/possible_colors = list("red", "blue", "green", "purple")
 

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -23,7 +23,6 @@
 	light_on = FALSE
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	block_chance = 0
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -9,7 +9,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
 	name = "fire axe"
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
-	force = 5
+	force = 12
 	throwforce = 15
 	demolition_mod = 1.25
 	w_class = WEIGHT_CLASS_BULKY
@@ -24,9 +24,9 @@
 	wound_bonus = -15
 	bare_wound_bonus = 20
 	/// How much damage to do unwielded
-	var/force_unwielded = 5
+	var/force_unwielded = 12
 	/// How much damage to do wielded
-	var/force_wielded = 24
+	var/force_wielded = 18
 
 /obj/item/fireaxe/Initialize(mapload)
 	. = ..()
@@ -64,8 +64,8 @@
 	base_icon_state = "bone_axe"
 	name = "bone axe"
 	desc = "A large, vicious axe crafted out of several sharpened bone plates and crudely tied together. Made of monsters, by killing monsters, for killing monsters."
-	force_unwielded = 5
-	force_wielded = 23
+	force_unwielded = 12
+	force_wielded = 20
 
 /*
  * Metal Hydrogen Axe
@@ -75,8 +75,8 @@
 	base_icon_state = "metalh2_axe"
 	name = "metallic hydrogen axe"
 	desc = "A lightweight crowbar with an extreme sharp fire axe head attached. It trades it's hefty as a weapon by making it easier to carry around when holstered to suits without having to sacrifice your backpack."
-	force_unwielded = 5
-	force_wielded = 15
+	force_unwielded = 12
+	force_wielded = 22
 	demolition_mod = 2
 	tool_behaviour = TOOL_CROWBAR
 	toolspeed = 1

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -135,8 +135,6 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A sharpened bone. The bare minimum in survival."
-	force = 12
-	throwforce = 15
 	custom_materials = null
 
 /obj/item/knife/combat/cyborg

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -10,9 +10,8 @@
 	desc = "The original knife, it is said that all other knives are only copies of this one."
 	flags_1 = CONDUCT_1
 	force = 10
-	demolition_mod = 0.75
 	w_class = WEIGHT_CLASS_SMALL
-	throwforce = 10
+	throwforce = 15
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throw_speed = 3
 	throw_range = 6
@@ -25,6 +24,7 @@
 	wound_bonus = 5
 	bare_wound_bonus = 15
 	tool_behaviour = TOOL_KNIFE
+	embedding = list("ignore_throwspeed_threshold" = TRUE)
 
 /obj/item/knife/Initialize(mapload)
 	. = ..()
@@ -115,9 +115,8 @@
 	name = "combat knife"
 	icon_state = "buckknife"
 	desc = "A military combat utility survival knife."
-	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
-	force = 20
-	throwforce = 20
+	force = 12
+	throwforce = 15
 	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "cuts")
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "cut")
 	bayonet = TRUE
@@ -125,9 +124,8 @@
 /obj/item/knife/combat/survival
 	name = "survival knife"
 	icon_state = "survivalknife"
-	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
 	desc = "A hunting grade survival knife."
-	force = 15
+	force = 12
 	throwforce = 15
 	bayonet = TRUE
 
@@ -139,8 +137,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A sharpened bone. The bare minimum in survival."
-	embedding = list("pain_mult" = 4, "embed_chance" = 35, "fall_chance" = 10)
-	force = 15
+	force = 12
 	throwforce = 15
 	custom_materials = null
 
@@ -158,11 +155,8 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	desc = "A makeshift glass shiv."
-	force = 8
-	throwforce = 12
 	attack_verb_continuous = list("shanks", "shivs")
 	attack_verb_simple = list("shank", "shiv")
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	custom_materials = list(/datum/material/glass=400)
 
 /obj/item/knife/shiv/plasma
@@ -170,9 +164,8 @@
 	icon_state = "plasmashiv"
 	inhand_icon_state = "plasmashiv"
 	desc = "A makeshift plasma glass shiv."
-	force = 9
-	throwforce = 13
-	armor = list(MELEE = 25, BULLET = 25, LASER = 25, ENERGY = 25, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50)
+	force = 12
+	throwforce = 15
 	custom_materials = list(/datum/material/glass=400, /datum/material/plasma=200)
 
 /obj/item/knife/shiv/titanium
@@ -180,10 +173,8 @@
 	icon_state = "titaniumshiv"
 	inhand_icon_state = "titaniumshiv"
 	desc = "A makeshift titanium-infused glass shiv."
-	throwforce = 14
-	throw_range = 7
-	wound_bonus = 10
-	armor = list(MELEE = 25, BULLET = 25, LASER = 25, ENERGY = 25, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50)
+	force = 12
+	throwforce = 15
 	custom_materials = list(/datum/material/glass=400, /datum/material/titanium=200)
 
 /obj/item/knife/shiv/plastitanium
@@ -191,13 +182,8 @@
 	icon_state = "plastitaniumshiv"
 	inhand_icon_state = "plastitaniumshiv"
 	desc = "A makeshift titanium-infused plasma glass shiv."
-	force = 10
+	force = 12
 	throwforce = 15
-	throw_speed = 4
-	throw_range = 8
-	wound_bonus = 10
-	bare_wound_bonus = 20
-	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 0, FIRE = 75, ACID = 75)
 	custom_materials = list(/datum/material/glass=400, /datum/material/alloy/plastitanium=200)
 
 /obj/item/knife/shiv/carrot

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -125,8 +125,6 @@
 	name = "survival knife"
 	icon_state = "survivalknife"
 	desc = "A hunting grade survival knife."
-	force = 12
-	throwforce = 15
 	bayonet = TRUE
 
 /obj/item/knife/combat/bone

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -834,6 +834,6 @@
 	inhand_icon_state = "prod"
 	worn_icon_state = "stunprod"
 	
-	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_BULKY
 	active_w_class = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -7,7 +7,7 @@
 	desc = "A haphazardly-constructed, deadly weapon of ancient design."
 	force = 12
 	w_class = WEIGHT_CLASS_BULKY
-	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BACK
 	throwforce = 20
 	throw_speed = 2
 	demolition_mod = 0.75

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -230,7 +230,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	name = "javelin"
 	desc = "A short spear ideal for throwing, crudely crafted from maintenance supplies."
-	force = 12
+	force = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 15
 	throw_speed = 2

--- a/code/game/objects/items/storage/personalshield.dm
+++ b/code/game/objects/items/storage/personalshield.dm
@@ -334,4 +334,4 @@
 
 	activation_time = 1
 
-	cell = /obj/item/stock_parts/cell/infinite
+	cell_type = /obj/item/stock_parts/cell/infinite

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -9,8 +9,8 @@
 	usesound = 'sound/items/crowbar.ogg'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	force = 5
-	throwforce = 7
+	force = 8
+	throwforce = 12
 	demolition_mod = 1.25
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -420,8 +420,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 
 	AddComponent(/datum/component/transforming, \
 		start_transformed = start_extended, \
-		force_on = 20, \
-		throwforce_on = 23, \
+		force_on = 12, \
+		throwforce_on = 15, \
 		throw_speed_on = throw_speed, \
 		sharpness_on = SHARP_EDGED, \
 		hitsound_on = 'sound/weapons/bladeslice.ogg', \
@@ -450,8 +450,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "Should anything ever go wrong..."
 	icon = 'icons/obj/weapons/items_and_weapons.dmi'
 	icon_state = "red_phone"
-	force = 3
-	throwforce = 2
+	force = 12
+	throwforce = 15
 	throw_speed = 3
 	throw_range = 4
 	w_class = WEIGHT_CLASS_SMALL
@@ -474,8 +474,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	inhand_icon_state = "stick"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	force = 5
-	throwforce = 5
+	force = 10
+	throwforce = 12
 	w_class = WEIGHT_CLASS_SMALL
 	custom_materials = list(/datum/material/iron=50)
 	attack_verb_continuous = list("bludgeons", "whacks", "disciplines", "thrashes")
@@ -524,8 +524,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	inhand_icon_state = "staff"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
-	force = 3
-	throwforce = 5
+	force = 10
+	throwforce = 12
 	throw_speed = 2
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
@@ -689,9 +689,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	inhand_icon_state = "baseball_bat"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	force = 12
-	wound_bonus = -10
-	throwforce = 12
+	force = 15
+	throwforce = 18
 	demolition_mod = 1.25
 	attack_verb_continuous = list("beats", "smacks")
 	attack_verb_simple = list("beat", "smack")
@@ -820,8 +819,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "This bat is made of highly reflective, highly armored material."
 	icon_state = "baseball_bat_metal"
 	inhand_icon_state = "baseball_bat_metal"
-	force = 12
-	throwforce = 15
+	force = 18
+	throwforce = 20
 	mob_thrower = TRUE
 
 /obj/item/melee/baseball_bat/ablative/IsReflect()//some day this will reflect thrown items instead of lasers
@@ -940,8 +939,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	block_chance = 20
 	sharpness = SHARP_EDGED
-	force = 14
-	throwforce = 12
+	force = 18
+	throwforce = 20
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
@@ -956,13 +955,10 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	worn_icon_state = "hfrequency0"
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
-	force = 10
-	wound_bonus = 25
-	bare_wound_bonus = 50
-	throwforce = 25
+	force = 18
+	throwforce = 20
 	throw_speed = 4
 	embedding = list("embed_chance" = 100)
-	block_chance = 25
 	sharpness = SHARP_EDGED
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -8,6 +8,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	flash_protect = FLASH_PROTECTION_WELDER
+	armor = GENERIC_ARMOR_T3
 
 /obj/item/clothing/head/hooded/cult_hoodie/eldritch/Initialize(mapload)
 	. = ..()
@@ -23,7 +24,7 @@
 	allowed = list(/obj/item/melee/sickly_blade)
 	hoodtype = /obj/item/clothing/head/hooded/cult_hoodie/eldritch
 	// Slightly better than normal cult robes
-	armor = list(MELEE = 50, BULLET = 50, LASER = 50,ENERGY = 50, BOMB = 35, BIO = 20, FIRE = 20, ACID = 20)
+	armor = GENERIC_ARMOR_T3
 
 /obj/item/clothing/suit/hooded/cultrobes/eldritch/examine(mob/user)
 	. = ..()
@@ -46,7 +47,7 @@
 	flags_inv = NONE
 	flags_cover = NONE
 	item_flags = EXAMINE_SKIP
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
+	armor = GENERIC_ARMOR_T2
 
 /obj/item/clothing/head/hooded/cult_hoodie/void/Initialize(mapload)
 	. = ..()
@@ -63,7 +64,7 @@
 	flags_inv = NONE
 	body_parts_covered = CHEST|GROIN|ARMS
 	// slightly worse than normal cult robes
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30,ENERGY = 30, BOMB = 15, BIO = 0, FIRE = 0, ACID = 0)
+	armor = GENERIC_ARMOR_T2
 	alternative_mode = TRUE
 
 /obj/item/clothing/suit/hooded/cultrobes/void/Initialize(mapload)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -287,29 +287,29 @@
 		. += how_cool_are_your_threads.Join()
 
 	if(armor.bio || armor.bomb || armor.bullet || armor.energy || armor.laser || armor.melee || armor.fire || armor.acid || flags_cover & HEADCOVERSMOUTH || flags_cover & PEPPERPROOF)
-		. += span_notice("It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.")
+		. += span_notice("This looks like it offers some protection. <a href='?src=[REF(src)];list_armor=1'>Take a closer look.</a>")
 
 /obj/item/clothing/Topic(href, href_list)
 	. = ..()
 
 	if(href_list["list_armor"])
-		var/list/readout = list("<span class='notice'><u><b>PROTECTION CLASSES</u></b>")
+		var/list/readout = list("<span class='notice'><u><b>DAMAGE MITIGATION</u></b>")
 		if(armor.bio || armor.bomb || armor.bullet || armor.energy || armor.laser || armor.melee)
-			readout += "\n<b>ARMOR (I-X)</b>"
-			if(armor.bio)
-				readout += "\nBIOHAZARD [armor_to_protection_class(armor.bio)]"
-			if(armor.bomb)
-				readout += "\nEXPLOSIVE [armor_to_protection_class(armor.bomb)]"
+			readout += "\n<b>ARMOR</b>"
+			if(armor.melee)
+				readout += "\nMELEE [armor_to_protection_class(armor.melee)]"
 			if(armor.bullet)
 				readout += "\nBULLET [armor_to_protection_class(armor.bullet)]"
 			if(armor.energy)
 				readout += "\nENERGY [armor_to_protection_class(armor.energy)]"
 			if(armor.laser)
 				readout += "\nLASER [armor_to_protection_class(armor.laser)]"
-			if(armor.melee)
-				readout += "\nMELEE [armor_to_protection_class(armor.melee)]"
+			if(armor.bio)
+				readout += "\nBIOHAZARD [armor_to_protection_class(armor.bio)]"
+			if(armor.bomb)
+				readout += "\nEXPLOSIVE [armor_to_protection_class(armor.bomb)]"
 		if(armor.fire || armor.acid)
-			readout += "\n<b>DURABILITY (I-X)</b>"
+			readout += "\n<b>DURABILITY</b>"
 			if(armor.fire)
 				readout += "\nFIRE [armor_to_protection_class(armor.fire)]"
 			if(armor.acid)
@@ -337,7 +337,7 @@
 /obj/item/clothing/proc/armor_to_protection_class(armor_value)
 	if (armor_value < 0)
 		. = "-"
-	. += "\Roman[round(abs(armor_value), 10) / 10]"
+	. += "[armor_value]"
 	return .
 
 /obj/item/clothing/atom_break(damage_flag)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -7,7 +7,7 @@
 	desc = "A piece of headgear used in dangerous working conditions to proect the head. Comes with a built-in flashlight."
 	icon_state = "hardhat0_yellow"
 	inhand_icon_state = null
-	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 10, BOMB = 20, BIO = 50, FIRE = 100, ACID = 50, WOUND = 10) // surprisingly robust against head trauma
+	armor = GENERIC_HARDHAT_ARMOR
 	flags_inv = 0
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	clothing_flags = SNUG_FIT | PLASMAMAN_HELMET_EXEMPT

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -5,7 +5,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	icon_state = "helmet"
 	inhand_icon_state = "helmet"
-	armor = list(MELEE = 20, BULLET = 20, LASER = 20,ENERGY = 20, BOMB = 40, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
+	armor = GENERIC_ARMOR_T2
 	cold_protection = HEAD
 	min_cold_protection_temperature = HELMET_MIN_TEMP_PROTECT
 	heat_protection = HEAD
@@ -56,7 +56,7 @@
 	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "helmetalt"
 	inhand_icon_state = "helmet"
-	armor = list(MELEE = 20, BULLET = 30, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
+	armor = GENERIC_ARMOR_BULLET
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/alt/Initialize(mapload)
@@ -68,7 +68,6 @@
 	desc = "A tactical black helmet, sealed from outside hazards with a plate of glass and not much else."
 	icon_state = "marine_command"
 	inhand_icon_state = "marine_helmet"
-	armor = list(MELEE = 50, BULLET = 50, LASER = 30, ENERGY = 25, BOMB = 50, BIO = 100, FIRE = 40, ACID = 50, WOUND = 20)
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
 	resistance_flags = FIRE_PROOF | ACID_PROOF
@@ -139,7 +138,7 @@
 	inhand_icon_state = "riot_helmet"
 	toggle_message = "You pull the visor down on"
 	alt_toggle_message = "You push the visor up on"
-	armor = list(MELEE = 30, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
+	armor = GENERIC_ARMOR_MELEE
 	flags_inv = HIDEEARS|HIDEFACE|HIDESNOUT
 	strip_delay = 80
 	actions_types = list(/datum/action/item_action/toggle)
@@ -188,17 +187,9 @@
 
 /obj/item/clothing/head/helmet/swat
 	name = "\improper SWAT helmet"
-	desc = "An extremely robust, space-worthy helmet in a nefarious red and black stripe pattern."
+	desc = "An extremely robust helmet in a nefarious red and black stripe pattern."
 	icon_state = "swatsyndie"
 	inhand_icon_state = "swatsyndie_helmet"
-	armor = list(MELEE = 40, BULLET = 30, LASER = 30,ENERGY = 40, BOMB = 50, BIO = 90, FIRE = 100, ACID = 100, WOUND = 15)
-	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
-	heat_protection = HEAD
-	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	clothing_flags = STOPSPRESSUREDAMAGE | PLASMAMAN_HELMET_EXEMPT
-	strip_delay = 80
-	resistance_flags = FIRE_PROOF | ACID_PROOF
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/swat/nanotrasen
@@ -206,48 +197,30 @@
 	desc = "An extremely robust helmet with the Nanotrasen logo emblazoned on the top."
 	icon_state = "swat"
 	inhand_icon_state = "swat_helmet"
-	clothing_flags = PLASMAMAN_HELMET_EXEMPT
-	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
-	heat_protection = HEAD
-	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
-
 
 /obj/item/clothing/head/helmet/thunderdome
 	name = "\improper Thunderdome helmet"
 	desc = "<i>'Let the battle commence!'</i>"
-	flags_inv = HIDEEARS|HIDEHAIR
 	icon_state = "thunderdome"
 	inhand_icon_state = "thunderdome_helmet"
-	armor = list(MELEE = 80, BULLET = 80, LASER = 50, ENERGY = 50, BOMB = 100, BIO = 100, FIRE = 90, ACID = 90)
-	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
-	heat_protection = HEAD
-	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	strip_delay = 80
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/thunderdome/holosuit
-	cold_protection = null
-	heat_protection = null
-	armor = list(MELEE = 10, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/head/helmet/roman
 	name = "\improper Roman helmet"
 	desc = "An ancient helmet made of bronze and leather."
 	flags_inv = HIDEEARS|HIDEHAIR
 	flags_cover = HEADCOVERSEYES
-	armor = list(MELEE = 20, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 100, ACID = 50, WOUND = 10)
+	armor = GENERIC_ARMOR_T1
 	resistance_flags = FIRE_PROOF
 	icon_state = "roman"
 	inhand_icon_state = "roman_helmet"
-	strip_delay = 100
 	dog_fashion = null
 
 /obj/item/clothing/head/helmet/roman/fake
 	desc = "An ancient helmet made of plastic and leather."
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	armor = TOTALLY_UNARMORED
 
 /obj/item/clothing/head/helmet/roman/legionnaire
 	name = "\improper Roman legionnaire helmet"
@@ -256,7 +229,7 @@
 
 /obj/item/clothing/head/helmet/roman/legionnaire/fake
 	desc = "An ancient helmet made of plastic and leather. Has a red crest on top of it."
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
+	armor = TOTALLY_UNARMORED
 
 /obj/item/clothing/head/helmet/gladiator
 	name = "gladiator helmet"
@@ -273,7 +246,7 @@
 	icon_state = "redtaghelm"
 	flags_cover = HEADCOVERSEYES
 	inhand_icon_state = "redtag_helmet"
-	armor = list(MELEE = 15, BULLET = 10, LASER = 20,ENERGY = 10, BOMB = 20, BIO = 0, FIRE = 0, ACID = 50)
+	armor = GENERIC_ARMOR_T1
 	// Offer about the same protection as a hardhat.
 	dog_fashion = null
 
@@ -283,7 +256,7 @@
 	icon_state = "bluetaghelm"
 	flags_cover = HEADCOVERSEYES
 	inhand_icon_state = "bluetag_helmet"
-	armor = list(MELEE = 15, BULLET = 10, LASER = 20,ENERGY = 10, BOMB = 20, BIO = 0, FIRE = 0, ACID = 50)
+	armor = GENERIC_ARMOR_T1
 	// Offer about the same protection as a hardhat.
 	dog_fashion = null
 
@@ -292,7 +265,7 @@
 	desc = "A classic metal helmet."
 	icon_state = "knight_green"
 	inhand_icon_state = "knight_helmet"
-	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80) // no wound armor cause getting domed in a bucket head sounds like concussion city
+	armor = GENERIC_ARMOR_MELEE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	strip_delay = 80
@@ -312,7 +285,6 @@
 	desc = "A classic medieval helmet, if you hold it upside down you could see that it's actually a bucket."
 	icon_state = "knight_greyscale"
 	inhand_icon_state = null
-	armor = list(MELEE = 35, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, FIRE = 40, ACID = 40)
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS //Can change color and add prefix
 
 /obj/item/clothing/head/helmet/skull
@@ -320,7 +292,6 @@
 	desc = "An intimidating tribal helmet, it doesn't look very comfortable."
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDESNOUT
 	flags_cover = HEADCOVERSEYES
-	armor = list(MELEE = 35, BULLET = 25, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50)
 	icon_state = "skull"
 	inhand_icon_state = null
 	strip_delay = 100
@@ -330,16 +301,12 @@
 	desc = "A helmet made from durathread and leather."
 	icon_state = "durathread"
 	inhand_icon_state = "durathread_helmet"
-	resistance_flags = FLAMMABLE
-//	armor = list(MELEE = 20, BULLET = 10, LASER = 30, ENERGY = 40, BOMB = 15, BIO = 0, FIRE = 40, ACID = 50, WOUND = 5)
-	strip_delay = 60
 
 /obj/item/clothing/head/helmet/rus_helmet
 	name = "russian helmet"
 	desc = "It can hold a bottle of vodka."
 	icon_state = "rus_helmet"
 	inhand_icon_state = "rus_helmet"
-//	armor = list(MELEE = 25, BULLET = 30, LASER = 0, ENERGY = 10, BOMB = 10, BIO = 0, FIRE = 20, ACID = 50, WOUND = 5)
 
 /obj/item/clothing/head/helmet/rus_helmet/Initialize(mapload)
 	. = ..()
@@ -354,21 +321,19 @@
 	body_parts_covered = HEAD
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
-//	armor = list(MELEE = 25, BULLET = 20, LASER = 20, ENERGY = 30, BOMB = 20, BIO = 50, FIRE = -10, ACID = 50, WOUND = 5)
 
 /obj/item/clothing/head/helmet/elder_atmosian
 	name = "\improper Elder Atmosian Helmet"
 	desc = "A superb helmet made with the toughest and rarest materials available to man."
 	icon_state = "h2helmet"
 	inhand_icon_state = "h2_helmet"
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 30, BOMB = 85, BIO = 10, FIRE = 65, ACID = 40, WOUND = 15)
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS //Can change color and add prefix
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 
 // scoundrel content
 
-// the main, all-purpose helmet. use this instead of the parent
+// the main, all-purpose helmet. generally, use this ingame instead of the parent
 /obj/item/clothing/head/helmet/scoundrel
 	name = "helmet"
 	desc = "A general-purpose helmet employed by private security and industrial contractors alike. It offers reasonable protection and \

--- a/code/modules/clothing/shoes/sneakers.dm
+++ b/code/modules/clothing/shoes/sneakers.dm
@@ -16,11 +16,6 @@
 	desc = "A pair of black shoes."
 	//custom_price = PAYCHECK_CREW
 
-	cold_protection = FEET
-	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
-	heat_protection = FEET
-	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
-
 /obj/item/clothing/shoes/sneakers/brown
 	name = "brown shoes"
 	desc = "A pair of brown shoes."

--- a/code/modules/clothing/spacesuits/bountyhunter.dm
+++ b/code/modules/clothing/spacesuits/bountyhunter.dm
@@ -4,7 +4,7 @@
 	icon_state = "hunter"
 	inhand_icon_state = "swat_suit"
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/knife/combat)
-	armor = list(MELEE = 60, BULLET = 40, LASER = 40, ENERGY = 50, BOMB = 100, BIO = 100, FIRE = 100, ACID = 100)
+	armor = GENERIC_ARMOR_T2_SEALED
 	strip_delay = 130
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	cell = /obj/item/stock_parts/cell/hyper

--- a/code/modules/clothing/spacesuits/freedom.dm
+++ b/code/modules/clothing/spacesuits/freedom.dm
@@ -5,7 +5,7 @@
 	worn_icon = 'icons/mob/clothing/head/costume.dmi'
 	icon_state = "griffinhat"
 	inhand_icon_state = null
-	armor = list(MELEE = 20, BULLET = 40, LASER = 30, ENERGY = 40, BOMB = 100, BIO = 100, FIRE = 80, ACID = 80)
+	armor = GENERIC_ARMOR_T2_SEALED
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = ACID_PROOF | FIRE_PROOF
@@ -16,7 +16,7 @@
 	icon_state = "freedom"
 	inhand_icon_state = null
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
-	armor = list(MELEE = 20, BULLET = 40, LASER = 30,ENERGY = 40, BOMB = 100, BIO = 100, FIRE = 80, ACID = 80)
+	armor = GENERIC_ARMOR_T2_SEALED
 	strip_delay = 130
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = ACID_PROOF | FIRE_PROOF

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -48,7 +48,7 @@
 	worn_icon_state = "syndi"
 	icon_state = "syndi"
 	inhand_icon_state = "space_suit_syndicate"
-	armor = list(MELEE = 30, BULLET = 35, LASER = 30, ENERGY = 30, BOMB = 80, BIO = 100, FIRE = 70, ACID = 100)
+	armor = GENERIC_ARMOR_T3_SEALED
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 	allowed = list(
@@ -69,6 +69,6 @@
 	worn_icon_state = "syndi"
 	icon_state = "syndi"
 
-	armor = list(MELEE = 30, BULLET = 35, LASER = 30, ENERGY = 30, BOMB = 80, BIO = 100, FIRE = 70, ACID = 100)
+	armor = GENERIC_ARMOR_T3_SEALED
 	flash_protect = FLASH_PROTECTION_WELDER
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/clothing/spacesuits/pirate.dm
+++ b/code/modules/clothing/spacesuits/pirate.dm
@@ -3,7 +3,7 @@
 	desc = "A modified helmet to allow space pirates to intimidate their customers whilst staying safe from the void. Comes with some additional protection."
 	icon_state = "spacepirate"
 	inhand_icon_state = "space_pirate_helmet"
-	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 60, ACID = 75)
+	armor = GENERIC_ARMOR_T2_SEALED
 	strip_delay = 40
 	equip_delay_other = 20
 
@@ -17,6 +17,6 @@
 	icon_state = "spacepirate"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/restraints/handcuffs, /obj/item/tank/internals, /obj/item/melee/energy/sword/pirate, /obj/item/clothing/glasses/eyepatch, /obj/item/reagent_containers/cup/glass/bottle/rum)
-	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 60, ACID = 75)
+	armor = GENERIC_ARMOR_T2_SEALED
 	strip_delay = 40
 	equip_delay_other = 20

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -4,7 +4,7 @@
 	icon_state = "syndicate"
 	inhand_icon_state = "space_syndicate"
 	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
-	armor = list(MELEE = 40, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 80, ACID = 85)
+	armor = GENERIC_ARMOR_T2_SEALED
 
 /obj/item/clothing/suit/space/syndicate
 	name = "red space suit"
@@ -13,7 +13,7 @@
 	desc = "Has a tag on it: Totally not property of an enemy corporation, honest!"
 	w_class = WEIGHT_CLASS_NORMAL
 	allowed = list(/obj/item/gun, /obj/item/ammo_box, /obj/item/ammo_casing, /obj/item/melee/baton, /obj/item/melee/energy/sword/saber, /obj/item/restraints/handcuffs, /obj/item/tank/internals)
-	armor = list(MELEE = 40, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 80, ACID = 85)
+	armor = GENERIC_ARMOR_T2_SEALED
 	cell = /obj/item/stock_parts/cell/hyper
 
 //Green syndicate space suit

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -62,6 +62,7 @@
 //generic allowed list
 GLOBAL_LIST_INIT(generic_suit_allowed, typecacheof(list(
 		// misc
+		/obj/item/modular_computer/tablet/pda,
 		/obj/item/flashlight,
 		/obj/item/radio,
 		/obj/item/storage/bag/construction,
@@ -76,10 +77,23 @@ GLOBAL_LIST_INIT(generic_suit_allowed, typecacheof(list(
 		/obj/item/t_scanner,
 		// weapons
 		/obj/item/melee/tonfa,
-		/obj/item/fireaxe/metal_h2_axe,
+		/obj/item/fireaxe,
+		/obj/item/spear,
+		/obj/item/javelin,
 		/obj/item/gun,
 		/obj/item/knife,
 		// shield
 		/obj/item/personalshield,
 	)))
 
+/obj/item/clothing/suit/space/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.space_suit_allowed
+
+/obj/item/clothing/suit/utility/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.space_suit_allowed
+
+GLOBAL_LIST_INIT(space_suit_allowed, typecacheof(list(
+		/obj/item/tank/internals,
+	)))

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -9,7 +9,6 @@
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/tank/jetpack/oxygen/captain,
 		)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 	slot_flags = ITEM_SLOT_OCLOTHING
@@ -83,3 +82,4 @@ GLOBAL_LIST_INIT(generic_suit_allowed, typecacheof(list(
 		// shield
 		/obj/item/personalshield,
 	)))
+

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -181,6 +181,7 @@
 	inhand_icon_state = null
 	blood_overlay_type = "armor"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	armor = GENERIC_ARMOR_MELEE
 
 /obj/item/clothing/suit/armor/bulletproof
 	name = "bulletproof armor"
@@ -275,6 +276,7 @@
 	icon_state = "knight_green"
 	inhand_icon_state = null
 	allowed = list(/obj/item/nullrod, /obj/item/claymore, /obj/item/banner, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
+	armor = GENERIC_ARMOR_MELEE
 
 /obj/item/clothing/suit/armor/riot/knight/yellow
 	icon_state = "knight_yellow"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -11,7 +11,7 @@
 	equip_delay_other = 40
 	max_integrity = 250
 	resistance_flags = NONE
-	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
+	armor = GENERIC_ARMOR_T2
 
 /obj/item/clothing/suit/armor/Initialize(mapload)
 	. = ..()
@@ -41,7 +41,6 @@
 	inhand_icon_state = "armor"
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(MELEE = 50, BULLET = 50, LASER = 30, ENERGY = 25, BOMB = 50, BIO = 100, FIRE = 40, ACID = 50, WOUND = 20)
 	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT_OFF
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -86,7 +85,6 @@
 	icon_state = "hos"
 	inhand_icon_state = "greatcoat"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 70, ACID = 90, WOUND = 10)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	strip_delay = 80
@@ -124,8 +122,6 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS|HANDS
 	heat_protection = CHEST|GROIN|ARMS|HANDS
-	strip_delay = 70
-	resistance_flags = FLAMMABLE
 	dog_fashion = null
 
 /obj/item/clothing/suit/armor/vest/warden/alt
@@ -149,7 +145,6 @@
 	icon_state = "capcarapace"
 	inhand_icon_state = "armor"
 	body_parts_covered = CHEST|GROIN
-	armor = list(MELEE = 50, BULLET = 40, LASER = 50, ENERGY = 50, BOMB = 25, BIO = 0, FIRE = 100, ACID = 90, WOUND = 10)
 	dog_fashion = null
 	resistance_flags = FIRE_PROOF
 
@@ -171,16 +166,13 @@
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"
-	desc = "A suit of semi-flexible polycarbonate body armor with heavy padding to protect against melee attacks. Helps the wearer resist shoving in close quarters."
+	desc = "A suit of semi-flexible polycarbonate body armor with heavy padding to protect against melee attacks."
 	icon_state = "riot"
 	inhand_icon_state = "swat_suit"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80, WOUND = 20)
-	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
-	strip_delay = 80
-	equip_delay_other = 60
+	armor = GENERIC_ARMOR_MELEE
 
 /obj/item/clothing/suit/armor/bone
 	name = "bone armor"
@@ -188,7 +180,6 @@
 	icon_state = "bonearmor"
 	inhand_icon_state = null
 	blood_overlay_type = "armor"
-	armor = list(MELEE = 35, BULLET = 25, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50, WOUND = 10)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 
 /obj/item/clothing/suit/armor/bulletproof
@@ -197,9 +188,7 @@
 	icon_state = "bulletproof"
 	inhand_icon_state = "armor"
 	blood_overlay_type = "armor"
-	armor = list(MELEE = 15, BULLET = 60, LASER = 10, ENERGY = 10, BOMB = 40, BIO = 0, FIRE = 50, ACID = 50, WOUND = 20)
-	strip_delay = 70
-	equip_delay_other = 50
+	armor = GENERIC_ARMOR_BULLET
 
 /obj/item/clothing/suit/armor/laserproof
 	name = "reflector vest"
@@ -210,7 +199,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
-	armor = list(MELEE = 10, BULLET = 10, LASER = 60, ENERGY = 60, BOMB = 0, BIO = 0, FIRE = 100, ACID = 100)
+	armor = GENERIC_ARMOR_ENERGY
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/hit_reflect_chance = 50
 
@@ -224,7 +213,6 @@
 	name = "detective's armor vest"
 	desc = "An armored vest with a detective's badge on it."
 	icon_state = "detective-armor"
-	resistance_flags = FLAMMABLE
 	dog_fashion = null
 
 /obj/item/clothing/suit/armor/vest/det_suit/Initialize(mapload)
@@ -236,15 +224,6 @@
 	desc = "A tactical suit first developed in a joint effort by the defunct IS-ERI and Nanotrasen in 2321 for military operations. It has a minor slowdown, but offers decent protection."
 	icon_state = "heavy"
 	inhand_icon_state = "swat_suit"
-	armor = list(MELEE = 40, BULLET = 30, LASER = 30,ENERGY = 40, BOMB = 50, BIO = 90, FIRE = 100, ACID = 100, WOUND = 15)
-	strip_delay = 120
-	resistance_flags = FIRE_PROOF | ACID_PROOF
-	clothing_flags = THICKMATERIAL
-	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT_OFF
-	heat_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
-	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
-	slowdown = 0.7
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 
 //All of the armor below is mostly unused
@@ -255,19 +234,15 @@
 	icon_state = "heavy"
 	inhand_icon_state = "swat_suit"
 	w_class = WEIGHT_CLASS_BULKY
-	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 3
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(MELEE = 80, BULLET = 80, LASER = 50, ENERGY = 50, BOMB = 100, BIO = 100, FIRE = 90, ACID = 90)
 
 /obj/item/clothing/suit/armor/tdome
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	clothing_flags = THICKMATERIAL
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(MELEE = 80, BULLET = 80, LASER = 50, ENERGY = 50, BOMB = 100, BIO = 100, FIRE = 90, ACID = 90)
 
 /obj/item/clothing/suit/armor/tdome/red
 	name = "thunderdome suit"
@@ -283,9 +258,6 @@
 
 /obj/item/clothing/suit/armor/tdome/holosuit
 	name = "thunderdome suit"
-	armor = list(MELEE = 10, BULLET = 10, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
-	cold_protection = null
-	heat_protection = null
 
 /obj/item/clothing/suit/armor/tdome/holosuit/red
 	desc = "Reddish armor."
@@ -322,7 +294,6 @@
 	icon_state = "knight_greyscale"
 	inhand_icon_state = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS//Can change color and add prefix
-	armor = list(MELEE = 35, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, FIRE = 40, ACID = 40, WOUND = 15)
 
 /obj/item/clothing/suit/armor/vest/durathread
 	name = "durathread vest"
@@ -333,14 +304,12 @@
 	equip_delay_other = 40
 	max_integrity = 200
 	resistance_flags = FLAMMABLE
-	armor = list(MELEE = 20, BULLET = 10, LASER = 30, ENERGY = 40, BOMB = 15, BIO = 0, FIRE = 40, ACID = 50)
 
 /obj/item/clothing/suit/armor/vest/russian
 	name = "russian vest"
 	desc = "A bulletproof vest with forest camo. Good thing there's plenty of forests to hide in around here, right?"
 	icon_state = "rus_armor"
 	inhand_icon_state = null
-	armor = list(MELEE = 25, BULLET = 30, LASER = 0, ENERGY = 10, BOMB = 10, BIO = 0, FIRE = 20, ACID = 50, WOUND = 10)
 
 /obj/item/clothing/suit/armor/vest/russian_coat
 	name = "russian battle coat"
@@ -350,7 +319,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
-	armor = list(MELEE = 25, BULLET = 20, LASER = 20, ENERGY = 30, BOMB = 20, BIO = 50, FIRE = -10, ACID = 50, WOUND = 10)
 
 /obj/item/clothing/suit/armor/elder_atmosian
 	name = "\improper Elder Atmosian Armor"
@@ -358,7 +326,6 @@
 	icon_state = "h2armor"
 	inhand_icon_state = null
 	material_flags = MATERIAL_EFFECTS | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS//Can change color and add prefix
-	armor = list(MELEE = 25, BULLET = 20, LASER = 30, ENERGY = 30, BOMB = 85, BIO = 10, FIRE = 65, ACID = 40, WOUND = 15)
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -369,7 +336,6 @@
 	icon_state = "centcom_formal"
 	inhand_icon_state = "centcom"
 	body_parts_covered = CHEST|GROIN|ARMS
-	armor = list(MELEE = 35, BULLET = 40, LASER = 40, ENERGY = 50, BOMB = 35, BIO = 10, FIRE = 10, ACID = 60)
 
 /obj/item/clothing/suit/armor/centcom_formal/Initialize(mapload)
 	. = ..()

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -7,7 +7,7 @@
 	icon_state = "bio"
 	inhand_icon_state = "bio_hood"
 	clothing_flags = THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT | HEADINTERNALS
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 30, ACID = 100)
+	armor = GENERIC_ARMOR_BIO
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
 	resistance_flags = ACID_PROOF
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
@@ -24,7 +24,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 0.5
 	allowed = list(/obj/item/tank/internals, /obj/item/reagent_containers/dropper, /obj/item/flashlight/pen, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/reagent_containers/cup/beaker, /obj/item/gun/syringe)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 30, ACID = 100)
+	armor = GENERIC_ARMOR_BIO
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	strip_delay = 70
 	equip_delay_other = 70
@@ -46,11 +46,9 @@
 
 //Security biosuit, grey with red stripe across the chest
 /obj/item/clothing/head/bio_hood/security
-	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 100, FIRE = 30, ACID = 100)
 	icon_state = "bio_security"
 
 /obj/item/clothing/suit/bio_suit/security
-	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 100, FIRE = 30, ACID = 100)
 	icon_state = "bio_security"
 
 /obj/item/clothing/suit/bio_suit/security/Initialize(mapload)

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -10,9 +10,6 @@
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	armor = GENERIC_ARMOR_MELEE
-	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
-	strip_delay = 80
-	equip_delay_other = 60
 
 /obj/item/clothing/suit/hooded/chaplainsuit
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/cup/glass/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)

--- a/code/modules/clothing/suits/chaplainsuits.dm
+++ b/code/modules/clothing/suits/chaplainsuits.dm
@@ -9,7 +9,7 @@
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80, WOUND = 20)
+	armor = GENERIC_ARMOR_MELEE
 	clothing_flags = BLOCKS_SHOVE_KNOCKDOWN
 	strip_delay = 80
 	equip_delay_other = 60
@@ -106,7 +106,7 @@
 	desc = "It has the unyielding gaze of a god eternally forgotten."
 	icon_state = "clockwork_helmet"
 	inhand_icon_state = null
-	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80)
+	armor = GENERIC_ARMOR_MELEE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	strip_delay = 8 SECONDS
@@ -128,7 +128,7 @@
 	worn_icon = 'icons/mob/clothing/head/chaplain.dmi'
 	icon_state = "knight_templar"
 	inhand_icon_state = null
-	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 0, FIRE = 80, ACID = 80)
+	armor = GENERIC_ARMOR_MELEE
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	strip_delay = 80
@@ -192,7 +192,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	slowdown = 2.0 //gotta pretend we're balanced.
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	armor = list(MELEE = 50, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 60, BIO = 0, FIRE = 60, ACID = 60)
+	armor = GENERIC_ARMOR_MELEE
 
 /obj/item/clothing/suit/chaplainsuit/armor/crusader/red
 	icon_state = "crusader-red"

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -269,7 +269,7 @@
 	desc = "A slimming piece of dubious space carp technology, you suspect it won't stand up to hand-to-hand blows."
 	icon_state = "carp_suit"
 	inhand_icon_state = "space_suit_syndicate"
-	armor = GENERIC_ARMOR_VULNERABILITY_T1 //As whimpy whimpy whoo
+	armor = GENERIC_ARMOR_T1_SEALED //As whimpy whimpy whoo
 	allowed = list(/obj/item/tank/internals, /obj/item/gun/ballistic/rifle/boltaction/harpoon) //I'm giving you a hint here
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -285,7 +285,7 @@
 	name = "carp helmet"
 	desc = "Spaceworthy and it looks like a space carp's head, smells like one too."
 	icon_state = "carp_helm"
-	armor = GENERIC_ARMOR_VULNERABILITY_T1 //As whimpy as a space carp
+	armor = GENERIC_ARMOR_T1_SEALED //As whimpy as a space carp
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACIALHAIR //facial hair will clip with the helm, this'll need a dynamic_fhair_suffix at some point.
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
@@ -454,7 +454,7 @@
 	name = "bronze suit"
 	desc = "A big and clanky suit made of bronze that offers no protection and looks very unfashionable. Nice."
 	icon_state = "clockwork_cuirass_old"
-	armor = GENERIC_ARMOR_VULNERABILITY_T1
+	armor = TOTALLY_UNARMORED
 
 /obj/item/clothing/suit/hooded/mysticrobe
 	name = "mystic's robe"

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -31,7 +31,7 @@
 	species_exception = list(/datum/species/golem)
 
 /obj/item/clothing/suit/costume/pirate/armored
-	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 60, ACID = 75)
+	armor = GENERIC_ARMOR_T2
 	strip_delay = 40
 	equip_delay_other = 20
 	species_exception = null
@@ -43,7 +43,7 @@
 	inhand_icon_state = null
 
 /obj/item/clothing/suit/costume/pirate/armored
-	armor = list(MELEE = 30, BULLET = 50, LASER = 30,ENERGY = 40, BOMB = 30, BIO = 30, FIRE = 60, ACID = 75)
+	armor = GENERIC_ARMOR_T2
 	strip_delay = 40
 	equip_delay_other = 20
 	species_exception = null
@@ -65,7 +65,7 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-	armor = list(MELEE = 35, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50)
+	armor = GENERIC_ARMOR_T2
 
 /obj/item/clothing/suit/costume/judgerobe
 	name = "judge's robe"
@@ -269,7 +269,7 @@
 	desc = "A slimming piece of dubious space carp technology, you suspect it won't stand up to hand-to-hand blows."
 	icon_state = "carp_suit"
 	inhand_icon_state = "space_suit_syndicate"
-	armor = list(MELEE = -20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 60, ACID = 75) //As whimpy whimpy whoo
+	armor = GENERIC_ARMOR_VULNERABILITY_T1 //As whimpy whimpy whoo
 	allowed = list(/obj/item/tank/internals, /obj/item/gun/ballistic/rifle/boltaction/harpoon) //I'm giving you a hint here
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -285,7 +285,7 @@
 	name = "carp helmet"
 	desc = "Spaceworthy and it looks like a space carp's head, smells like one too."
 	icon_state = "carp_helm"
-	armor = list(MELEE = -20, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 100, FIRE = 60, ACID = 75) //As whimpy as a space carp
+	armor = GENERIC_ARMOR_VULNERABILITY_T1 //As whimpy as a space carp
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEFACIALHAIR //facial hair will clip with the helm, this'll need a dynamic_fhair_suffix at some point.
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
@@ -454,7 +454,7 @@
 	name = "bronze suit"
 	desc = "A big and clanky suit made of bronze that offers no protection and looks very unfashionable. Nice."
 	icon_state = "clockwork_cuirass_old"
-	armor = list(MELEE = 5, BULLET = 0, LASER = -5, ENERGY = -15, BOMB = 10, BIO = 0, FIRE = 20, ACID = 20)
+	armor = GENERIC_ARMOR_VULNERABILITY_T1
 
 /obj/item/clothing/suit/hooded/mysticrobe
 	name = "mystic's robe"
@@ -485,7 +485,7 @@
 	icon = 'icons/obj/clothing/suits/armor.dmi'
 	worn_icon = 'icons/mob/clothing/suits/armor.dmi'
 	inhand_icon_state = null
-	armor = list(MELEE = 25, BULLET = 15, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, FIRE = 50, ACID = 50)
+	armor = GENERIC_ARMOR_T2
 
 /obj/item/clothing/suit/costume/hawaiian
 	name = "hawaiian overshirt"

--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -66,7 +66,6 @@
 	desc = "A thick jacket with a rubbery, water-resistant shell."
 	icon_state = "pufferjacket"
 	inhand_icon_state = "hostrench"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 	species_exception = list(/datum/species/golem/bone)
 
 /obj/item/clothing/suit/jacket/puffer/vest
@@ -76,7 +75,6 @@
 	inhand_icon_state = "armor"
 	body_parts_covered = CHEST|GROIN
 	cold_protection = CHEST|GROIN
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 30, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/suit/jacket/miljacket
 	name = "military jacket"
@@ -119,5 +117,5 @@
 	desc = "A durable jacket made of space-grade polymer-nanoweave. The protection from radiation burns makes jackets like these common choice for EVA specialists."
 	icon_state = "bomberjacket"
 	inhand_icon_state = "brownjsuit"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 50, ACID = 0)
+	armor = GENERIC_ENV_ARMOR_T1
 	clothing_traits = list(TRAIT_RADIATION_PROTECTED_CLOTHING)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -98,7 +98,7 @@
 	inhand_icon_state = "det_suit"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|ARMS
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 0, BIO = 0, FIRE = 0, ACID = 45)
+	armor = GENERIC_ARMOR_ENERGY
 	cold_protection = CHEST|GROIN|ARMS
 	heat_protection = CHEST|GROIN|ARMS
 
@@ -277,7 +277,7 @@
 		/obj/item/storage/bag/books,
 		/obj/item/tank/internals,
 	)
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 0, BIO = 0, FIRE = 0, ACID = 45)
+	armor = GENERIC_ARMOR_T1
 	cold_protection = CHEST|ARMS
 	heat_protection = CHEST|ARMS
 
@@ -308,7 +308,7 @@
 	name = "research director's coat"
 	desc = "A mix between a labcoat and just a regular coat. It's made out of a special anti-bacterial, anti-acidic, and anti-biohazardous synthetic fabric."
 	icon_state = "labcoat_rd"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 75, FIRE = 75, ACID = 75)
+	armor = GENERIC_ENV_ARMOR_T1
 	body_parts_covered = CHEST|GROIN|ARMS
 
 /obj/item/clothing/suit/jacket/research_director/Initialize(mapload)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -27,7 +27,6 @@
 		/obj/item/storage/bag/plants,
 	)
 	species_exception = list(/datum/species/golem)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/suit/apron/waders
 	name = "horticultural waders"
@@ -66,7 +65,6 @@
 	inhand_icon_state = "chef"
 	icon = 'icons/obj/clothing/suits/jacket.dmi'
 	worn_icon = 'icons/mob/clothing/suits/jacket.dmi'
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 0)
 	body_parts_covered = CHEST|GROIN|ARMS
 	allowed = list(
 		/obj/item/kitchen,

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -306,7 +306,7 @@
 	name = "research director's coat"
 	desc = "A mix between a labcoat and just a regular coat. It's made out of a special anti-bacterial, anti-acidic, and anti-biohazardous synthetic fabric."
 	icon_state = "labcoat_rd"
-	armor = GENERIC_ENV_ARMOR_T1
+	armor = GENERIC_ENV_ARMOR_T2
 	body_parts_covered = CHEST|GROIN|ARMS
 
 /obj/item/clothing/suit/jacket/research_director/Initialize(mapload)

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -28,7 +28,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 50, ACID = 50)
+	armor = GENERIC_ENV_ARMOR_T1
 	species_exception = list(/datum/species/golem)
 
 /obj/item/clothing/suit/toggle/labcoat/cmo

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -28,7 +28,7 @@
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
 		)
-	armor = GENERIC_ENV_ARMOR_T1
+	armor = GENERIC_ENV_ARMOR_T2
 	species_exception = list(/datum/species/golem)
 
 /obj/item/clothing/suit/toggle/labcoat/cmo

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -33,7 +33,7 @@
 	icon_state = "reactiveoff"
 	inhand_icon_state = null
 	blood_overlay_type = "armor"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 100)
+	armor = GENERIC_ARMOR_T1
 	actions_types = list(/datum/action/item_action/toggle)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	hit_reaction_chance = 50

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -28,7 +28,7 @@
 		/obj/item/tank/internals,
 	)
 	slowdown = 0.5
-	armor = list(MELEE = 15, BULLET = 5, LASER = 20, ENERGY = 20, BOMB = 20, BIO = 50, FIRE = 100, ACID = 50)
+	armor = GENERIC_ARMOR_T2_FIRE
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -70,7 +70,7 @@
 	desc = "Use in case of bomb."
 	icon_state = "bombsuit"
 	clothing_flags = THICKMATERIAL | SNUG_FIT
-	armor = list(MELEE = 20, BULLET = 0, LASER = 20,ENERGY = 30, BOMB = 100, BIO = 0, FIRE = 80, ACID = 50)
+	armor = GENERIC_ARMOR_BOMB
 	flags_inv = HIDEFACE|HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
 
 	cold_protection = HEAD
@@ -91,7 +91,7 @@
 	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	slowdown = 0.5
-	armor = list(MELEE = 20, BULLET = 0, LASER = 20,ENERGY = 30, BOMB = 100, BIO = 50, FIRE = 80, ACID = 50)
+	armor = GENERIC_ARMOR_BOMB
 	flags_inv = HIDEJUMPSUIT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
@@ -128,7 +128,7 @@
 	desc = "A hood with radiation protective properties. The label reads, 'Made with lead. Please do not consume insulation.'"
 	clothing_flags = THICKMATERIAL | SNUG_FIT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 60, FIRE = 30, ACID = 30)
+	armor = GENERIC_ENV_ARMOR_T1
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
@@ -152,7 +152,7 @@
 		/obj/item/tank/internals,
 		)
 	slowdown = 0.5
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 60, FIRE = 30, ACID = 30)
+	armor = GENERIC_ENV_ARMOR_T1
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_inv = HIDEJUMPSUIT

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -28,7 +28,7 @@
 		/obj/item/tank/internals,
 	)
 	slowdown = 0.5
-	armor = GENERIC_ARMOR_T2_FIRE
+	armor = GENERIC_ARMOR_T1_FIRE
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -128,7 +128,7 @@
 	desc = "A hood with radiation protective properties. The label reads, 'Made with lead. Please do not consume insulation.'"
 	clothing_flags = THICKMATERIAL | SNUG_FIT
 	flags_inv = HIDEMASK|HIDEEARS|HIDEFACE|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDESNOUT
-	armor = GENERIC_ENV_ARMOR_T1
+	armor = GENERIC_ENV_ARMOR_T2
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
@@ -152,7 +152,7 @@
 		/obj/item/tank/internals,
 		)
 	slowdown = 0.5
-	armor = GENERIC_ENV_ARMOR_T1
+	armor = GENERIC_ENV_ARMOR_T2
 	strip_delay = 60
 	equip_delay_other = 60
 	flags_inv = HIDEJUMPSUIT

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -46,7 +46,7 @@
 	icon_state = "coateva"
 	w_class = WEIGHT_CLASS_BULKY
 	slowdown = 0.75
-	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 50, FIRE = 50, ACID = 20)
+	armor = GENERIC_ENV_ARMOR_T1
 	strip_delay = 6 SECONDS
 	equip_delay_other = 6 SECONDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT // Protects very cold.
@@ -64,7 +64,7 @@
 	name = "\proper Endotherm winter hood"
 	desc = "A thickly padded hood attached to an even thicker coat."
 	icon_state = "hood_eva"
-	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 10, BOMB = 0, BIO = 50, FIRE = 50, ACID = 20)
+	armor = GENERIC_ENV_ARMOR_T1
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	clothing_flags = THICKMATERIAL|SNUG_FIT // Snug fit doesn't really matter, but might as well
@@ -76,7 +76,7 @@
 	desc = "A luxurious winter coat woven in the bright green and gold colours of Central Command. It has a small pin in the shape of the Nanotrasen logo for a zipper."
 	icon_state = "coatcentcom"
 	inhand_icon_state = null
-	armor = list(MELEE = 35, BULLET = 40, LASER = 40, ENERGY = 50, BOMB = 35, BIO = 10, FIRE = 10, ACID = 60)
+	armor = GENERIC_ARMOR_T3
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/centcom
 
 /obj/item/clothing/suit/hooded/wintercoat/centcom/Initialize(mapload)
@@ -85,7 +85,7 @@
 
 /obj/item/clothing/head/hooded/winterhood/centcom
 	icon_state = "hood_centcom"
-	armor = list(MELEE = 35, BULLET = 40, LASER = 40, ENERGY = 50, BOMB = 35, BIO = 10, FIRE = 10, ACID = 60)
+	armor = GENERIC_ARMOR_T3
 
 // Captain
 /obj/item/clothing/suit/hooded/wintercoat/captain
@@ -95,7 +95,7 @@
 			Extremely lavish, and extremely durable."
 	icon_state = "coatcaptain"
 	inhand_icon_state = "coatcaptain"
-	armor = list(MELEE = 25, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 0, ACID = 50)
+	armor = GENERIC_ARMOR_T2
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
 /obj/item/clothing/suit/hooded/wintercoat/captain/Initialize(mapload)
@@ -104,7 +104,7 @@
 
 /obj/item/clothing/head/hooded/winterhood/captain
 	icon_state = "hood_captain"
-	armor = list(MELEE = 25, BULLET = 30, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 0, ACID = 50)
+	armor = GENERIC_ARMOR_T2
 
 // Head of Personnel
 /obj/item/clothing/suit/hooded/wintercoat/hop
@@ -112,7 +112,7 @@
 	desc = "A cozy winter coat, covered in thick fur. The breast features a proud yellow chevron, reminding everyone that you're the second banana."
 	icon_state = "coathop"
 	inhand_icon_state = null
-	armor = list(MELEE = 10, BULLET = 15, LASER = 15, ENERGY = 25, BOMB = 10, BIO = 0, FIRE = 0, ACID = 35)
+	armor = GENERIC_ARMOR_T2
 	allowed = list(
 		/obj/item/melee/baton/telescopic,
 	)
@@ -168,7 +168,7 @@
 	desc = "A red, armour-padded winter coat. It glitters with a mild ablative coating and a robust air of authority.  The zipper tab is a pair of jingly little handcuffs that get annoying after the first ten seconds."
 	icon_state = "coatsecurity"
 	inhand_icon_state = "coatsecurity"
-	armor = list(MELEE = 25, BULLET = 15, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 0, ACID = 45)
+	armor = GENERIC_ARMOR_T2
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/security
 
 /obj/item/clothing/suit/hooded/wintercoat/security/Initialize(mapload)
@@ -178,7 +178,7 @@
 /obj/item/clothing/head/hooded/winterhood/security
 	desc = "A red, armour-padded winter hood. Definitely not bulletproof, especially not the part where your face goes."
 	icon_state = "hood_security"
-	armor = list(MELEE = 25, BULLET = 15, LASER = 30, ENERGY = 40, BOMB = 25, BIO = 0, FIRE = 0, ACID = 45)
+	armor = GENERIC_ARMOR_T2
 
 // Medical Doctor
 /obj/item/clothing/suit/hooded/wintercoat/medical
@@ -199,13 +199,11 @@
 		/obj/item/sensor_device,
 		/obj/item/storage/pill_bottle,
 	)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 40, FIRE = 10, ACID = 20)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical
 
 /obj/item/clothing/head/hooded/winterhood/medical
 	desc = "A white winter coat hood."
 	icon_state = "hood_medical"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 40, FIRE = 10, ACID = 20)
 
 // Chief Medical Officer
 /obj/item/clothing/suit/hooded/wintercoat/medical/cmo
@@ -213,7 +211,6 @@
 	desc = "A winter coat in a vibrant shade of blue with a small silver caduceus instead of a plastic zipper tab. The normal liner is replaced with an exceptionally thick, soft layer of fur."
 	icon_state = "coatcmo"
 	inhand_icon_state = null
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 20, ACID = 30)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/medical/cmo
 
 /obj/item/clothing/suit/hooded/wintercoat/medical/cmo/Initialize(mapload)
@@ -225,7 +222,6 @@
 /obj/item/clothing/head/hooded/winterhood/medical/cmo
 	desc = "A blue winter coat hood."
 	icon_state = "hood_cmo"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 20, ACID = 30)
 
 // Chemist
 /obj/item/clothing/suit/hooded/wintercoat/medical/chemistry
@@ -290,14 +286,12 @@
 		/obj/item/storage/bag/xeno,
 		/obj/item/storage/pill_bottle,
 	)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, FIRE = 20, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science
 	species_exception = list(/datum/species/golem)
 
 /obj/item/clothing/head/hooded/winterhood/science
 	desc = "A white winter coat hood. This one will keep your brain warm. About as much as the others, really."
 	icon_state = "hood_science"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 10, BIO = 0, FIRE = 20, ACID = 0)
 
 // Research Director
 /obj/item/clothing/suit/hooded/wintercoat/science/rd
@@ -305,7 +299,6 @@
 	desc = "A thick arctic winter coat with an outdated atomic model instead of a plastic zipper tab. Most in the know are heavily aware that Bohr's model of the atom was outdated by the time of the 1930s when the Heisenbergian and Schrodinger models were generally accepted for true. Nevertheless, we still see its use in anachronism, roleplaying, and, in this case, as a zipper tab. At least it should keep you warm on your ivory pillar."
 	icon_state = "coatrd"
 	inhand_icon_state = null
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 0, FIRE = 30, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science/rd
 
 /obj/item/clothing/suit/hooded/wintercoat/science/rd/Initialize(mapload)
@@ -317,7 +310,6 @@
 /obj/item/clothing/head/hooded/winterhood/science/rd
 	desc = "A white winter coat hood. It smells faintly of hair gel."
 	icon_state = "hood_rd"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 20, BIO = 0, FIRE = 30, ACID = 0)
 
 // Roboticist
 /obj/item/clothing/suit/hooded/wintercoat/science/robotics
@@ -357,7 +349,6 @@
 		/obj/item/storage/bag/construction,
 		/obj/item/t_scanner,
 	)
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 20, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering
 	species_exception = list(/datum/species/golem/uranium)
 
@@ -369,7 +360,6 @@
 /obj/item/clothing/head/hooded/winterhood/engineering
 	desc = "A yellow winter coat hood. Definitely not a replacement for a hard hat."
 	icon_state = "hood_engineer"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 20, ACID = 0)
 
 /obj/item/clothing/head/hooded/winterhood/engineering/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
@@ -382,7 +372,6 @@
 	desc = "A white winter coat with reflective green and yellow stripes. Stuffed with asbestos, treated with fire retardant PBDE, lined with a micro thin sheet of lead foil and snugly fitted to your body's measurements. This baby's ready to save you from anything except the thyroid cancer and systemic fibrosis you'll get from wearing it. The zipper tab is a tiny golden wrench."
 	icon_state = "coatce"
 	inhand_icon_state = null
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 30, ACID = 10)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/engineering/ce
 
 /obj/item/clothing/suit/hooded/wintercoat/engineering/ce/Initialize(mapload)
@@ -394,7 +383,6 @@
 /obj/item/clothing/head/hooded/winterhood/engineering/ce
 	desc = "A white winter coat hood. Feels surprisingly heavy. The tag says that it's not child safe."
 	icon_state = "hood_ce"
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 30, ACID = 10)
 
 // Atmospherics Technician
 /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
@@ -454,13 +442,11 @@
 		/obj/item/t_scanner/adv_mining_scanner,
 		/obj/item/tank/internals,
 	)
-	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/miner
 
 /obj/item/clothing/head/hooded/winterhood/miner
 	desc = "A dusty winter coat hood."
 	icon_state = "hood_miner"
-	armor = list(MELEE = 10, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 0, ACID = 0)
 
 /obj/item/clothing/suit/hooded/wintercoat/custom
 	name = "tailored winter coat"

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -46,7 +46,7 @@
 	icon_state = "coateva"
 	w_class = WEIGHT_CLASS_BULKY
 	slowdown = 0.75
-	armor = GENERIC_ENV_ARMOR_T1
+	armor = GENERIC_ENV_ARMOR_T2
 	strip_delay = 6 SECONDS
 	equip_delay_other = 6 SECONDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT // Protects very cold.
@@ -64,7 +64,7 @@
 	name = "\proper Endotherm winter hood"
 	desc = "A thickly padded hood attached to an even thicker coat."
 	icon_state = "hood_eva"
-	armor = GENERIC_ENV_ARMOR_T1
+	armor = GENERIC_ENV_ARMOR_T2
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
 	clothing_flags = THICKMATERIAL|SNUG_FIT // Snug fit doesn't really matter, but might as well

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -5,7 +5,7 @@
 	worn_icon = 'icons/mob/clothing/head/wizard.dmi'
 	icon_state = "wizard"
 	inhand_icon_state = "wizhat"
-	armor = list(MELEE = 30, BULLET = 20, LASER = 20, ENERGY = 30, BOMB = 20, BIO = 100, FIRE = 100, ACID = 100,  WOUND = 20)
+	armor = GENERIC_ARMOR_T2
 	strip_delay = 50
 	equip_delay_other = 50
 	clothing_flags = SNUG_FIT | CASTING_CLOTHES
@@ -67,7 +67,7 @@
 	worn_icon = 'icons/mob/clothing/suits/wizard.dmi'
 	inhand_icon_state = "wizrobe"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
-	armor = list(MELEE = 30, BULLET = 20, LASER = 20, ENERGY = 30, BOMB = 20, BIO = 100, FIRE = 100, ACID = 100, WOUND = 20)
+	armor = GENERIC_ARMOR_T2
 	allowed = list(/obj/item/teleportation_scroll, /obj/item/highfrequencyblade/wizard)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 50

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -6,7 +6,7 @@
 	righthand_file = 'icons/mob/inhands/clothing/suits_righthand.dmi'
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	slot_flags = ITEM_SLOT_ICLOTHING
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 10, FIRE = 0, ACID = 0, WOUND = 0)
+	armor = GENERIC_JUMPSUIT_ARMOR
 	equip_sound = 'sound/items/equip/jumpsuit_equip.ogg'
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -538,8 +538,9 @@
 
 /mob/living/carbon/update_stamina()
 	var/stam = getStaminaLoss()
-	var/harddam = getBruteLoss() + getFireLoss() // remove or change this line to 0 to remove hard damage consideration for stamcrit
-	if(stam > DAMAGE_PRECISION && (maxHealth - (stam + harddam)) <= crit_threshold)
+	var/harddam = getBruteLoss() + getFireLoss() + getCloneLoss() // remove or change this line to 0 to remove hard damage consideration for stamcrit
+	var/miscdam = getToxLoss() + getOxyLoss()
+	if(stam > DAMAGE_PRECISION && (maxHealth - (stam + harddam + miscdam)) <= crit_threshold)
 		if (!stat)
 			enter_stamcrit()
 	else if(HAS_TRAIT_FROM(src, TRAIT_INCAPACITATED, STAMINA))

--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -958,7 +958,7 @@
 		backed by inbuilt psi-emitters, heightening stressors common amongst Nanotrasen staff, and clouding identifiable information. \
 		Scrubbed statistical data presented a single correlation within documented psychological profiles. The fear of the Unknown."
 	default_skin = "infiltrator"
-	armor = list(MELEE = 50, BULLET = 50, LASER = 40, ENERGY = 50, BOMB = 40, BIO = 0, FIRE = 100, ACID = 100, WOUND = 25)
+	armor = GENERIC_ARMOR_T2
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	atom_flags = PREVENT_CONTENTS_EXPLOSION_1
 	siemens_coefficient = 0
@@ -966,7 +966,7 @@
 	slowdown_active = 0
 	ui_theme = "syndicate"
 	slot_flags = ITEM_SLOT_BELT
-	inbuilt_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/storage/belt, /obj/item/mod/module/demoralizer)
+	inbuilt_modules = list(/obj/item/mod/module/infiltrator, /obj/item/mod/module/storage/belt)
 	allowed_suit_storage = list(
 		/obj/item/ammo_box,
 		/obj/item/ammo_casing,

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -245,7 +245,7 @@
 	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts") //these won't show up if the pen is off
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_POINTY
-	armour_penetration = 20
+	armour_penetration = 50
 	bare_wound_bonus = 10
 	light_system = MOVABLE_LIGHT
 	light_range = 1.5
@@ -268,7 +268,7 @@
 	butcher_sound = 'sound/weapons/blade1.ogg', \
 	)
 	AddComponent(/datum/component/transforming, \
-		force_on = 18, \
+		force_on = 16, \
 		throwforce_on = 35, \
 		throw_speed_on = 4, \
 		sharpness_on = SHARP_EDGED, \

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -44,7 +44,7 @@
 	desc = "A shotgun shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
 	projectile_type = /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
-	pellets = 4
+	pellets = 5
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/stunslug
@@ -79,15 +79,15 @@
 	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
-	pellets = 6
-	variance = 25
+	pellets = 5
+	variance = 15
 
 /obj/item/ammo_casing/shotgun/rubbershot
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "rshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
-	pellets = 6
+	pellets = 5
 	variance = 20
 	custom_materials = list(/datum/material/iron=4000)
 
@@ -102,12 +102,12 @@
 
 /obj/item/ammo_casing/shotgun/improvised
 	name = "improvised shell"
-	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
+	desc = "A makeshift shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	custom_materials = list(/datum/material/iron=250)
-	pellets = 10
-	variance = 25
+	pellets = 5
+	variance = 35
 
 /obj/item/ammo_casing/shotgun/ion
 	name = "ion shell"
@@ -115,7 +115,7 @@
 	The unique properties of the crystal split the pulse into a spread of individually weaker bolts."
 	icon_state = "ionshell"
 	projectile_type = /obj/projectile/ion/weak
-	pellets = 4
+	pellets = 5
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/laserslug
@@ -123,7 +123,7 @@
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
 	projectile_type = /obj/projectile/beam/weak
-	pellets = 6
+	pellets = 5
 	variance = 35
 
 /obj/item/ammo_casing/shotgun/techshell

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -55,13 +55,13 @@
 
 /obj/item/ammo_casing/energy/laser/scatter
 	projectile_type = /obj/projectile/beam/scatter
-	pellets = 5
-	variance = 25
+	pellets = 7
+	variance = 15
 	select_name = "scatter"
 
 /obj/item/ammo_casing/energy/laser/scatter/disabler
 	projectile_type = /obj/projectile/beam/disabler
-	pellets = 3
+	pellets = 1
 	variance = 15
 	harmful = FALSE
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -10,7 +10,7 @@
 	select_name = "maim"
 
 /obj/item/ammo_casing/energy/laser/hellfire/antique
-	e_cost = 100
+	e_cost = 166
 
 /obj/item/ammo_casing/energy/lasergun
 	projectile_type = /obj/projectile/beam/laser
@@ -120,3 +120,8 @@
 /obj/item/ammo_casing/energy/nanite/cryo
 	projectile_type = /obj/projectile/energy/cryo
 	select_name = "cryo"
+
+// scoundrel content
+//used as a secondary for energy guns
+/obj/item/ammo_casing/energy/laser/secondary
+	projectile_type = /obj/projectile/beam/secondary

--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -44,23 +44,6 @@
 	if(!start_empty)
 		top_off(starting=TRUE)
 
-/obj/item/ammo_box/add_weapon_description()
-	AddElement(/datum/element/weapon_description, attached_proc = PROC_REF(add_notes_box))
-
-/obj/item/ammo_box/proc/add_notes_box()
-	var/list/readout = list()
-
-	if(caliber && max_ammo) // Text references a 'magazine' as only magazines generally have the caliber variable initialized
-		readout += "Up to [span_warning("[max_ammo] [caliber] rounds")] can be found within this magazine."
-		readout += "As a loaded projectile weapon, you get the impression this could do..."
-
-	var/obj/item/ammo_casing/mag_ammo = get_round(TRUE)
-
-	if(istype(mag_ammo))
-		readout += "\n[mag_ammo.add_notes_ammo()]"
-
-	return readout.Join("\n")
-
 /**
  * top_off is used to refill the magazine to max, in case you want to increase the size of a magazine with VV then refill it at once
  *

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -163,7 +163,7 @@
 
 	if(!chambered)
 		readout += "\nAs a loaded projectile weapon, you get the impression this could do..."
-		readout += "[span_warning("[projectile_damage_multiplier]")] damage per shot using standard [initial(exam_mag.caliber)] ammunition, but there's nothing chambered."
+		readout += "[span_warning("[projectile_damage_multiplier] force")] per shot using standard [initial(exam_mag.caliber)] ammunition, but there's nothing chambered."
 
 		return readout.Join("\n") // Sending over the singular string, rather than the whole list
 

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -157,10 +157,34 @@
  *
  */
 /obj/item/gun/ballistic/proc/add_notes_ballistic()
-	if(magazine) // Make sure you have a magazine, to get the notes from
-		return "\n[magazine.add_notes_box()]"
-	else
-		return "\nThe warning attached to the magazine is missing..."
+	var/list/readout = list()
+
+	var/obj/item/ammo_box/magazine/exam_mag = mag_type
+
+	if(!chambered)
+		readout += "\nAs a loaded projectile weapon, you get the impression this could do..."
+		readout += "[span_warning("[projectile_damage_multiplier]")] damage per shot using standard [initial(exam_mag.caliber)] ammunition, but there's nothing chambered."
+
+		return readout.Join("\n") // Sending over the singular string, rather than the whole list
+
+	var/obj/projectile/exam_proj
+	var/obj/item/ammo_casing/for_ammo = chambered
+	exam_proj = for_ammo.projectile_type
+	if(chambered)
+		readout += "\nAs a loaded projectile weapon, you get the impression this could do..."
+		if(initial(exam_proj.damage) > 0)
+			readout += "[span_warning("[initial(exam_proj.damage) * projectile_damage_multiplier * initial(for_ammo.pellets)] [initial(exam_proj.damage_type)] force")] per shot using the chambered ammunition, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)].")]"
+		if(initial(exam_proj.stamina) > 0)
+			readout += "[span_warning("[initial(exam_proj.stamina) * projectile_damage_multiplier * initial(for_ammo.pellets)] stamina force")] per shot using the chambered ammunition, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)].")]"
+		if(burst_size > 1)
+			readout += "Additionally, it seems to fire in bursts of [burst_size]."
+		if(initial(for_ammo.pellets) > 1)
+			readout += "\The [initial(for_ammo.name)] will eject in a cloud of roughly [span_warning("[initial(for_ammo.pellets)] pellets.")]"
+			
+		if(initial(exam_proj.nodamage = TRUE))
+			readout += "Probably nothing, in terms of damage -- but you never know."
+
+		return readout.Join("\n") // Sending over the singular string, rather than the whole list
 
 /obj/item/gun/ballistic/vv_edit_var(vname, vval)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -177,7 +177,7 @@
 		if(initial(exam_proj.stamina) > 0)
 			readout += "[span_warning("[initial(exam_proj.stamina) * projectile_damage_multiplier * initial(for_ammo.pellets)] stamina force")] per shot using the chambered ammunition, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)].")]"
 		if(burst_size > 1)
-			readout += "Additionally, it seems to fire in bursts of [burst_size]."
+			readout += "Additionally, it seems to fire in [span_warning("bursts of [burst_size].")]"
 		if(initial(for_ammo.pellets) > 1)
 			readout += "\The [initial(for_ammo.name)] will eject in a cloud of roughly [span_warning("[initial(for_ammo.pellets)] pellets.")]"
 			

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -343,6 +343,9 @@
 	suppressor_y_offset = 3
 	projectile_damage_multiplier = 70
 
+	force = 10
+	throwforce = 18
+
 /obj/item/gun/ballistic/automatic/sniper_rifle/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/scope, range_modifier = 2)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -213,7 +213,7 @@
 	bolt_type = BOLT_TYPE_OPEN
 	empty_indicator = TRUE
 	show_bolt_icon = FALSE
-	projectile_damage_multiplier = 4
+	projectile_damage_multiplier = 6
 
 /obj/item/gun/ballistic/automatic/tommygun/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -81,6 +81,7 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
+	projectile_damage_multiplier = 15
 
 /obj/item/gun/ballistic/automatic/c20r/update_overlays()
 	. = ..()
@@ -111,6 +112,7 @@
 	mag_display = TRUE
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
+	projectile_damage_multiplier = 30
 
 /obj/item/gun/ballistic/automatic/wt550/Initialize(mapload)
 	. = ..()
@@ -126,7 +128,7 @@
 	spread = 25
 	can_suppress = FALSE
 	actions_types = list()
-	projectile_damage_multiplier = 0.35 //It's like 10.5 damage per bullet, it's close enough to 10 shots
+	projectile_damage_multiplier = 10 //It's like 10.5 damage per bullet, it's close enough to 10 shots
 	mag_display = TRUE
 	empty_indicator = TRUE
 	fire_sound = 'sound/weapons/gun/smg/shot_alt.ogg'
@@ -141,6 +143,7 @@
 	show_bolt_icon = FALSE
 	mag_display = TRUE
 	rack_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
+	projectile_damage_multiplier = 10
 
 /obj/item/gun/ballistic/automatic/m90
 	name = "\improper M-90gl Carbine"
@@ -159,6 +162,7 @@
 	mag_display = TRUE
 	empty_indicator = TRUE
 	fire_sound = 'sound/weapons/gun/smg/shot_alt.ogg'
+	projectile_damage_multiplier = 18
 
 /obj/item/gun/ballistic/automatic/m90/Initialize(mapload)
 	. = ..()
@@ -209,6 +213,7 @@
 	bolt_type = BOLT_TYPE_OPEN
 	empty_indicator = TRUE
 	show_bolt_icon = FALSE
+	projectile_damage_multiplier = 4
 
 /obj/item/gun/ballistic/automatic/tommygun/Initialize(mapload)
 	. = ..()
@@ -224,7 +229,7 @@
 	can_suppress = FALSE
 	burst_size = 3
 	fire_delay = 1
-
+	projectile_damage_multiplier = 10
 
 // L6 SAW //
 
@@ -252,6 +257,7 @@
 	rack_sound = 'sound/weapons/gun/l6/l6_rack.ogg'
 	suppressed_sound = 'sound/weapons/gun/general/heavy_shot_suppressed.ogg'
 	var/cover_open = FALSE
+	projectile_damage_multiplier = 12
 
 /obj/item/gun/ballistic/automatic/l6_saw/unrestricted
 	pin = /obj/item/firing_pin
@@ -331,11 +337,12 @@
 	fire_delay = 4 SECONDS
 	burst_size = 1
 	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BACK
+	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
 	actions_types = list()
 	mag_display = TRUE
 	suppressor_x_offset = 3
 	suppressor_y_offset = 3
+	projectile_damage_multiplier = 70
 
 /obj/item/gun/ballistic/automatic/sniper_rifle/Initialize(mapload)
 	. = ..()
@@ -373,6 +380,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
+	projectile_damage_multiplier = 30
 
 // Laser rifle (rechargeable magazine) //
 
@@ -390,6 +398,7 @@
 	actions_types = list()
 	fire_sound = 'sound/weapons/laser.ogg'
 	casing_ejector = FALSE
+	projectile_damage_multiplier = 18
 
 // scoundrel content
 /obj/item/gun/ballistic/automatic/sniper_rifle/empty

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -321,7 +321,7 @@
 
 /obj/item/gun/ballistic/automatic/sniper_rifle
 	name = "sniper rifle"
-	desc = "A long ranged weapon that does significant damage. No, you can't quickscope."
+	desc = "A long ranged weapon that does significant damage."
 	icon_state = "sniper"
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "sniper"
@@ -336,8 +336,7 @@
 	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
 	fire_delay = 4 SECONDS
 	burst_size = 1
-	w_class = WEIGHT_CLASS_NORMAL
-	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BACK
 	actions_types = list()
 	mag_display = TRUE
 	suppressor_x_offset = 3

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -17,6 +17,7 @@
 	cartridge_wording = "arrow"
 	bolt_type = BOLT_TYPE_NO_BOLT
 	var/drawn = FALSE
+	projectile_damage_multiplier = 35
 
 /obj/item/gun/ballistic/bow/update_icon_state()
 	. = ..()
@@ -89,7 +90,7 @@
 	name = "arrow"
 	desc = "Ow! Get it out of me!"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow
-	damage = 50
+	damage = 1
 	speed = 1
 	range = 25
 

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -24,6 +24,7 @@
 	bolt_wording = "slide"
 	suppressor_x_offset = 10
 	suppressor_y_offset = -1
+	projectile_damage_multiplier = 30
 
 /obj/item/gun/ballistic/automatic/pistol/no_mag
 	spawnwithmagazine = FALSE
@@ -72,6 +73,7 @@
 	rack_sound = 'sound/weapons/gun/pistol/rack.ogg'
 	lock_back_sound = 'sound/weapons/gun/pistol/slide_lock.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'
+	projectile_damage_multiplier = 35
 
 /obj/item/gun/ballistic/automatic/pistol/deagle/gold
 	desc = "A gold plated Desert Eagle folded over a million times by superior martian gunsmiths. Uses .50 AE ammo."
@@ -96,7 +98,8 @@
 	spread = 10
 	actions_types = list(/datum/action/item_action/toggle_firemode)
 	suppressor_x_offset = 6
-
+	projectile_damage_multiplier = 12
+	
 /obj/item/gun/ballistic/automatic/pistol/stickman
 	name = "flat gun"
 	desc = "A 2 dimensional gun.. what?"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -16,6 +16,8 @@
 	var/recent_spin = 0
 	var/last_fire = 0
 
+	projectile_damage_multiplier = 45
+
 /obj/item/gun/ballistic/revolver/process_fire(atom/target, mob/living/user, message, params, zone_override, bonus_spread)
 	..()
 	last_fire = world.time
@@ -103,6 +105,7 @@
 	fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
 	icon_state = "c38"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev38
+	projectile_damage_multiplier = 30
 	initial_caliber = CALIBER_38
 	alternative_caliber = CALIBER_357
 	initial_fire_sound = 'sound/weapons/gun/revolver/shot.ogg'
@@ -111,7 +114,7 @@
 	alternative_ammo_misfires = TRUE
 	can_misfire = FALSE
 	misfire_probability = 0
-	misfire_percentage_increment = 25 //about 1 in 4 rounds, which increases rapidly every shot
+	misfire_percentage_increment = 1 // there's no positive to use 357 as of writing this, so this is a placeholder increment
 	obj_flags = UNIQUE_RENAME
 	unique_reskin = list("Default" = "c38",
 						"Fitz Special" = "c38_fitz",
@@ -133,8 +136,6 @@
 	name = "\improper Golden revolver"
 	desc = "This ain't no game, ain't never been no show, And I'll gladly gun down the oldest lady you know. Uses .357 ammo."
 	icon_state = "goldrevolver"
-	fire_sound = 'sound/weapons/resonator_blast.ogg'
-	recoil = 8
 	pin = /obj/item/firing_pin
 
 /obj/item/gun/ballistic/revolver/nagant

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -15,6 +15,7 @@
 	rack_sound = 'sound/weapons/gun/rifle/bolt_out.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/rifle/bolt_in.ogg'
 	tac_reloads = FALSE
+	projectile_damage_multiplier = 45
 
 /obj/item/gun/ballistic/rifle/rack(mob/user = null)
 	if (bolt_locked == FALSE)
@@ -165,7 +166,7 @@
 	can_bayonet = TRUE
 	knife_y_offset = 11
 	can_be_sawn_off = FALSE
-	projectile_damage_multiplier = 0.75
+	projectile_damage_multiplier = 45
 
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/handle_chamber()
 	. = ..()
@@ -182,7 +183,6 @@
 	can_jam = FALSE
 	misfire_probability = 0
 	misfire_percentage_increment = 0
-	projectile_damage_multiplier = 1
 
 /// MAGICAL BOLT ACTIONS + ARCANE BARRAGE? ///
 

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -15,7 +15,7 @@
 	rack_sound = 'sound/weapons/gun/rifle/bolt_out.ogg'
 	bolt_drop_sound = 'sound/weapons/gun/rifle/bolt_in.ogg'
 	tac_reloads = FALSE
-	projectile_damage_multiplier = 45
+	projectile_damage_multiplier = 40
 
 /obj/item/gun/ballistic/rifle/rack(mob/user = null)
 	if (bolt_locked == FALSE)
@@ -166,7 +166,6 @@
 	can_bayonet = TRUE
 	knife_y_offset = 11
 	can_be_sawn_off = FALSE
-	projectile_damage_multiplier = 45
 
 /obj/item/gun/ballistic/rifle/boltaction/pipegun/handle_chamber()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -14,6 +14,7 @@
 	load_sound = 'sound/weapons/gun/shotgun/insert_shell.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	force = 10
+	throwforce = 18
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/internal/shot

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -26,7 +26,7 @@
 	weapon_weight = WEAPON_HEAVY
 
 	pb_knockback = 2
-	projectile_damage_multiplier = 45
+	projectile_damage_multiplier = 40
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
 	. = 0
@@ -265,7 +265,7 @@
 	bolt_type = BOLT_TYPE_NO_BOLT
 	can_be_sawn_off = TRUE
 	pb_knockback = 3 // it's a super shotgun!
-	projectile_damage_multiplier = 35
+	projectile_damage_multiplier = 40
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/AltClick(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -26,6 +26,7 @@
 	weapon_weight = WEAPON_HEAVY
 
 	pb_knockback = 2
+	projectile_damage_multiplier = 45
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
 	. = 0
@@ -264,6 +265,7 @@
 	bolt_type = BOLT_TYPE_NO_BOLT
 	can_be_sawn_off = TRUE
 	pb_knockback = 3 // it's a super shotgun!
+	projectile_damage_multiplier = 35
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/AltClick(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -14,6 +14,7 @@
 	item_flags = NONE
 	gun_flags = TOY_FIREARM_OVERLAY | NOT_A_REAL_GUN
 	casing_ejector = FALSE
+	projectile_damage_multiplier = 15
 
 /obj/item/gun/ballistic/automatic/toy/unrestricted
 	pin = /obj/item/firing_pin

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -105,9 +105,9 @@
 			continue
 
 		if(initial(exam_proj.damage) > 0) // Don't divide by 0!!!!!
-			readout += "[span_warning("[FORCE_DESCRIPTIVE(initial(exam_proj.damage) * for_ammo.pellets)] [initial(exam_proj.damage_type)] force")] on [span_warning("[for_ammo.select_name]")] mode, taking about [span_warning("[HITS_TO_CRIT(initial(exam_proj.damage) * for_ammo.pellets)] [initial(exam_proj.armor_flag)]")] shots to [initial(exam_proj.damage_type) == STAMINA ? "down" : "critically injure"] someone, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)]")]."
+			readout += "[span_warning("[FORCE_DESCRIPTIVE((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] [initial(exam_proj.damage_type)] force")] on [span_warning("[for_ammo.select_name]")] mode, taking about [span_warning("[HITS_TO_CRIT((initial(exam_proj.damage) * projectile_damage_multiplier) * for_ammo.pellets)] [initial(exam_proj.armor_flag)]")] shots to [initial(exam_proj.damage_type) == STAMINA ? "down" : "critically injure"] someone, with an armor penetration of [span_warning("[initial(exam_proj.armour_penetration)]")]."
 			if(initial(exam_proj.stamina) > 0) // In case a projectile does damage AND stamina damage (Energy Crossbow)
-				readout += "[span_warning("[FORCE_DESCRIPTIVE(initial(exam_proj.stamina) * for_ammo.pellets)] stamina force")] on [span_warning("[for_ammo.select_name]")] mode."
+				readout += "[span_warning("[FORCE_DESCRIPTIVE((initial(exam_proj.stamina) * projectile_damage_multiplier) * for_ammo.pellets)] stamina force")] on [span_warning("[for_ammo.select_name]")] mode."
 		else
 			readout += "a theoretically infinite number of shots on [span_warning("[for_ammo.select_name]")] mode."
 

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -4,7 +4,7 @@
 	icon_state = "energy"
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = null //so the human update icon uses the icon_state instead.
-	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser/secondary)
 	modifystate = TRUE
 	ammo_x_offset = 3
 	dual_wield_spread = 60

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -8,6 +8,7 @@
 	modifystate = TRUE
 	ammo_x_offset = 3
 	dual_wield_spread = 60
+	projectile_damage_multiplier = 30
 
 /obj/item/gun/energy/e_gun/add_seclight_point()
 	AddComponent(/datum/component/seclite_attachable, \
@@ -191,3 +192,4 @@
 	single_shot_type_overlay = FALSE
 	force = 8
 	throwforce = 8
+	projectile_damage_multiplier = 25

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -8,6 +8,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = 1
+	projectile_damage_multiplier = 30
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -48,6 +48,7 @@
 	selfcharge = 1
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/antique)
+	projectile_damage_multiplier = 25
 
 /obj/item/gun/energy/laser/captain/scattershot
 	name = "scatter shot laser rifle"

--- a/code/modules/projectiles/guns/energy/pulse.dm
+++ b/code/modules/projectiles/guns/energy/pulse.dm
@@ -11,6 +11,7 @@
 	slot_flags = ITEM_SLOT_BACK
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/pulse, /obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser)
 	cell_type = /obj/item/stock_parts/cell/pulse
+	projectile_damage_multiplier = 45
 
 /obj/item/gun/energy/pulse/emp_act(severity)
 	return

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -108,6 +108,7 @@
 	can_bayonet = TRUE
 	knife_x_offset = 20
 	knife_y_offset = 12
+	projectile_damage_multiplier = 20
 
 /obj/item/gun/energy/recharge/ebow/halloween
 	name = "candy corn crossbow"
@@ -127,3 +128,4 @@
 	custom_materials = list(/datum/material/iron=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
+	projectile_damage_multiplier = 30

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -38,6 +38,7 @@
 	icon_state = "decloner"
 	ammo_type = list(/obj/item/ammo_casing/energy/declone)
 	ammo_x_offset = 1
+	projectile_damage_multiplier = 30
 
 /obj/item/gun/energy/decloner/update_overlays()
 	. = ..()
@@ -371,6 +372,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/tesla_cannon)
 	shaded_charge = TRUE
 	weapon_weight = WEAPON_HEAVY
+	projectile_damage_multiplier = 20
 
 /obj/item/gun/energy/tesla_cannon/Initialize(mapload)
 	. = ..()
@@ -392,6 +394,7 @@
 	var/coin_regen_rate = 2 SECONDS
 	/// The cooldown for regenning coins
 	COOLDOWN_DECLARE(coin_regen_cd)
+	projectile_damage_multiplier = 25
 
 /obj/item/gun/energy/marksman_revolver/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -143,7 +143,7 @@
 	var/homing_offset_x = 0
 	var/homing_offset_y = 0
 
-	var/damage = 10
+	var/damage = 1
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
 	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
 	///Defines what armor to use when it hits things.  Must be set to bullet, laser, energy, or bomb

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -22,11 +22,11 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-//overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
 	name = "hellfire laser"
 	wound_bonus = 10
-	damage = 1.25
+	damage = 1
+	armour_penetration = 10
 
 /obj/projectile/beam/laser/hellfire/Initialize(mapload)
 	. = ..()
@@ -35,7 +35,7 @@
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
-	damage = 1.5
+	damage = 1
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
@@ -49,7 +49,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/projectile/beam/weak
-	damage = 0.9
+	damage = 0.2
 
 /obj/projectile/beam/weak/penetrator
 	armour_penetration = 50
@@ -67,7 +67,7 @@
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"
-	damage = 0.9
+	damage = 1
 	range = 15
 	armour_penetration = 100
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
@@ -210,3 +210,7 @@
 	if(isopenturf(target) || isindestructiblewall(target))//shrunk floors wouldnt do anything except look weird, i-walls shouldn't be bypassable
 		return
 	target.AddComponent(/datum/component/shrink, shrink_time)
+
+// scoundrel content
+/obj/projectile/beam/secondary
+	damage = 0.67

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -2,7 +2,7 @@
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
-	damage = 20
+	damage = 1
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
@@ -16,23 +16,17 @@
 	ricochets_max = 50 //Honk!
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL
-	wound_bonus = -20
-	bare_wound_bonus = 10
-
 
 /obj/projectile/beam/laser
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
-	wound_bonus = -30
-	bare_wound_bonus = 40
 
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
 /obj/projectile/beam/laser/hellfire
 	name = "hellfire laser"
-	wound_bonus = 0
-	damage = 25
-	speed = 0.6 // higher power = faster, that's how light works right
+	wound_bonus = 10
+	damage = 1.25
 
 /obj/projectile/beam/laser/hellfire/Initialize(mapload)
 	. = ..()
@@ -41,7 +35,7 @@
 /obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
-	damage = 40
+	damage = 1.5
 	tracer_type = /obj/effect/projectile/tracer/heavy_laser
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
@@ -55,7 +49,7 @@
 		impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser/wall
 
 /obj/projectile/beam/weak
-	damage = 15
+	damage = 0.9
 
 /obj/projectile/beam/weak/penetrator
 	armour_penetration = 50
@@ -68,12 +62,12 @@
 /obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	damage = 0.1
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"
-	damage = 15
+	damage = 0.9
 	range = 15
 	armour_penetration = 100
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
@@ -87,7 +81,7 @@
 /obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 30
+	damage = 1
 	damage_type = STAMINA
 	armor_flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'
@@ -101,7 +95,7 @@
 /obj/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
-	damage = 50
+	damage = 1
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 	tracer_type = /obj/effect/projectile/tracer/pulse
@@ -118,7 +112,7 @@
 			SSexplosions.medturf += target
 
 /obj/projectile/beam/pulse/shotgun
-	damage = 30
+	damage = 1
 
 /obj/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"
@@ -132,14 +126,13 @@
 	pierce_hits -= 1
 	..()
 
+// don't use this for guns
 /obj/projectile/beam/emitter
 	name = "emitter beam"
 	icon_state = "emitter"
 	damage = 30
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
-	wound_bonus = -40
-	bare_wound_bonus = 70
 
 /obj/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
-	damage = 60
+	damage = 1
 	damage_type = BRUTE
 	nodamage = FALSE
 	armor_flag = BULLET

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -1,5 +1,5 @@
 /obj/projectile/bullet/incendiary
-	damage = 20
+	damage = 0.7
 	/// How many firestacks to apply to the target
 	var/fire_stacks = 4
 	/// If TRUE, leaves a trail of hotspots as it flies, very very chaotic
@@ -24,7 +24,7 @@
 
 /// Incendiary bullet that more closely resembles a real flamethrower sorta deal, no visible bullet, just flames.
 /obj/projectile/bullet/incendiary/fire
-	damage = 15
+	damage = 0.7
 	range = 6
 	alpha = 0
 	pass_flags = PASSTABLE | PASSMOB

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -1,34 +1,34 @@
 // C3D (Borgs)
 
 /obj/projectile/bullet/c3d
-	damage = 20
+	damage = 1
 
 // Mech LMG
 
 /obj/projectile/bullet/lmg
-	damage = 20
+	damage = 1
 
 // Mech FNX-99
 
 /obj/projectile/bullet/incendiary/fnx99
-	damage = 20
+	damage = 1
 
 // Turrets
 
 /obj/projectile/bullet/manned_turret
-	damage = 20
+	damage = 1
 
 /obj/projectile/bullet/manned_turret/hmg
 	icon_state = "redtrac"
 
 /obj/projectile/bullet/syndicate_turret
-	damage = 20
+	damage = 1
 
 // 7.12x82mm (SAW)
 
 /obj/projectile/bullet/mm712x82
 	name = "7.12x82mm bullet"
-	damage = 30
+	damage = 1
 	armour_penetration = 5
 	wound_bonus = -50
 	wound_falloff_tile = 0
@@ -39,7 +39,7 @@
 
 /obj/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow-point bullet"
-	damage = 50
+	damage = 1
 	sharpness = SHARP_EDGED
 	weak_against_armour = TRUE
 	wound_bonus = -40
@@ -48,7 +48,7 @@
 
 /obj/projectile/bullet/incendiary/mm712x82
 	name = "7.12x82mm incendiary bullet"
-	damage = 15
+	damage = 1
 	fire_stacks = 3
 
 /obj/projectile/bullet/mm712x82/match
@@ -60,7 +60,7 @@
 
 /obj/projectile/bullet/mm712x82/bouncy
 	name = "7.12x82mm rubber bullet"
-	damage = 20
+	damage = 1
 	ricochets_max = 40
 	ricochet_chance = 500 // will bounce off anything and everything, whether they like it or not
 	ricochet_auto_aim_range = 4

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -2,47 +2,47 @@
 
 /obj/projectile/bullet/c9mm
 	name = "9mm bullet"
-	damage = 30
+	damage = 1
 	embedding = list(embed_chance=15, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
 
 /obj/projectile/bullet/c9mm/ap
 	name = "9mm armor-piercing bullet"
-	damage = 27
+	damage = 0.9
 	armour_penetration = 40
 	embedding = null
 	shrapnel_type = null
 
 /obj/projectile/bullet/c9mm/hp
 	name = "9mm hollow-point bullet"
-	damage = 40
+	damage = 1.2
 	weak_against_armour = TRUE
 
 /obj/projectile/bullet/incendiary/c9mm
 	name = "9mm incendiary bullet"
-	damage = 15
+	damage = 0.7
 	fire_stacks = 2
 
 // 10mm
 
 /obj/projectile/bullet/c10mm
 	name = "10mm bullet"
-	damage = 40
+	damage = 1
 
 /obj/projectile/bullet/c10mm/ap
 	name = "10mm armor-piercing bullet"
-	damage = 35
+	damage = 0.9
 	armour_penetration = 40
 
 /obj/projectile/bullet/c10mm/hp
 	name = "10mm hollow-point bullet"
-	damage = 50
+	damage = 1.2
 	weak_against_armour = TRUE
 
 /obj/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"
-	damage = 20
-	fire_stacks = 3
+	damage = 0.7
+	fire_stacks = 2
 
 // scoundrel content
 /obj/projectile/bullet/c9mm/surplus
-	damage = 18
+	damage = 0.6

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -2,26 +2,23 @@
 
 /obj/projectile/bullet/n762
 	name = "7.62x38mmR bullet"
-	damage = 60
+	damage = 1
 
 // .50AE (Desert Eagle)
 
 /obj/projectile/bullet/a50ae
 	name = ".50AE bullet"
-	damage = 60
+	damage = 1
 
 // .38 (Detective's Gun)
 
 /obj/projectile/bullet/c38
 	name = ".38 bullet"
-	damage = 25
+	damage = 1
 	ricochets_max = 2
 	ricochet_chance = 50
 	ricochet_auto_aim_angle = 10
 	ricochet_auto_aim_range = 3
-	wound_bonus = -20
-	bare_wound_bonus = 10
-	embedding = list(embed_chance=25, fall_chance=2, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=5, rip_time=1 SECONDS)
 	embed_falloff_tile = -4
 
 /obj/projectile/bullet/c38/match
@@ -36,8 +33,8 @@
 
 /obj/projectile/bullet/c38/match/bouncy
 	name = ".38 Rubber bullet"
-	damage = 10
-	stamina = 30
+	damage = 0.3
+	stamina = 0.7
 	weak_against_armour = TRUE
 	ricochets_max = 6
 	ricochet_incidence_leeway = 0
@@ -50,7 +47,7 @@
 // premium .38 ammo from cargo, weak against armor, lower base damage, but excellent at embedding and causing slice wounds at close range
 /obj/projectile/bullet/c38/dumdum
 	name = ".38 DumDum bullet"
-	damage = 15
+	damage = 0.7
 	weak_against_armour = TRUE
 	ricochets_max = 0
 	sharpness = SHARP_EDGED
@@ -62,7 +59,7 @@
 
 /obj/projectile/bullet/c38/trac
 	name = ".38 TRAC bullet"
-	damage = 10
+	damage = 0.3
 	ricochets_max = 0
 
 /obj/projectile/bullet/c38/trac/on_hit(atom/target, blocked = FALSE)
@@ -80,7 +77,7 @@
 
 /obj/projectile/bullet/c38/hotshot //similar to incendiary bullets, but do not leave a flaming trail
 	name = ".38 Hot Shot bullet"
-	damage = 20
+	damage = 0.7
 	ricochets_max = 0
 
 /obj/projectile/bullet/c38/hotshot/on_hit(atom/target, blocked = FALSE)
@@ -92,7 +89,7 @@
 
 /obj/projectile/bullet/c38/iceblox //see /obj/projectile/temp for the original code
 	name = ".38 Iceblox bullet"
-	damage = 20
+	damage = 0.5
 	var/temperature = 100
 	ricochets_max = 0
 
@@ -106,8 +103,7 @@
 
 /obj/projectile/bullet/a357
 	name = ".357 bullet"
-	damage = 60
-	wound_bonus = -30
+	damage = 1
 
 // admin only really, for ocelot memes
 /obj/projectile/bullet/a357/match

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -2,14 +2,13 @@
 
 /obj/projectile/bullet/a556
 	name = "5.56mm bullet"
-	damage = 35
+	damage = 1
 	armour_penetration = 30
-	wound_bonus = -40
 
 /obj/projectile/bullet/a556/phasic
 	name = "5.56mm phasic bullet"
 	icon_state = "gaussphase"
-	damage = 20
+	damage = 0.8
 	armour_penetration = 70
 	projectile_phasing =  PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINE | PASSSTRUCTURE | PASSDOORS
 
@@ -17,24 +16,20 @@
 
 /obj/projectile/bullet/a762
 	name = "7.62 bullet"
-	damage = 60
+	damage = 1
 	armour_penetration = 10
-	wound_bonus = -45
-	wound_falloff_tile = 0
 
 /obj/projectile/bullet/a762/enchanted
 	name = "enchanted 7.62 bullet"
-	damage = 20
-	stamina = 80
+	damage = 0.2
+	stamina = 0.8
 
 // Harpoons (Harpoon Gun)
 
 /obj/projectile/bullet/harpoon
 	name = "harpoon"
 	icon_state = "gauss"
-	damage = 60
+	damage = 1
 	armour_penetration = 50
-	wound_bonus = -20
-	bare_wound_bonus = 80
 	embedding = list(embed_chance=100, fall_chance=3, jostle_chance=4, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=5, jostle_pain_mult=6, rip_time=10)
 	wound_falloff_tile = -5

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,7 +1,7 @@
 /obj/projectile/bullet/shotgun_slug
 	name = "12g shotgun slug"
 	icon_state = "pellet"
-	damage = 50
+	damage = 1
 	sharpness = SHARP_POINTY
 	wound_bonus = 0
 
@@ -18,8 +18,8 @@
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	icon_state = "pellet"
-	damage = 10
-	stamina = 55
+	damage = 0.2
+	stamina = 0.8
 	wound_bonus = 20
 	sharpness = NONE
 	embedding = null
@@ -27,16 +27,16 @@
 /obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
 	icon_state = "pellet"
-	damage = 20
+	damage = 0.7
 
 /obj/projectile/bullet/incendiary/shotgun/no_trail
 	name = "precision incendiary slug"
-	damage = 35
+	damage = 0.7
 	leaves_fire_trail = FALSE
 
 /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
-	damage = 5
+	damage = 0.1
 
 /obj/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
@@ -52,8 +52,7 @@
 /obj/projectile/bullet/shotgun_frag12
 	name ="frag12 slug"
 	icon_state = "pellet"
-	damage = 15
-	paralyze = 10
+	damage = 0.5
 
 /obj/projectile/bullet/shotgun_frag12/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -76,15 +75,15 @@
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
-	damage = 7.5
+	damage = 0.2
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
-	damage = 3
-	stamina = 11
+	damage = 0.1
+	stamina = 0.1
 	sharpness = NONE
 	embedding = null
 	speed = 1.2
@@ -105,15 +104,14 @@
 
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
-	damage = 1
-	stamina = 6
+	damage = 0.1
+	stamina = 0.1
 	embedding = null
 
 /obj/projectile/bullet/pellet/shotgun_improvised
-	tile_dropoff = 0.35 //Come on it does 6 damage don't be like that.
-	damage = 6
+	damage = 0.2
 	wound_bonus = 0
-	bare_wound_bonus = 7.5
+	bare_wound_bonus = 5
 
 /obj/projectile/bullet/pellet/shotgun_improvised/Initialize(mapload)
 	. = ..()
@@ -127,4 +125,4 @@
 
 /obj/projectile/bullet/scattershot
 	icon_state = "pellet"
-	damage = 24
+	damage = 0.2

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -2,35 +2,32 @@
 
 /obj/projectile/bullet/c45
 	name = ".45 bullet"
-	damage = 30
-	wound_bonus = -10
-	wound_falloff_tile = -10
+	damage = 1
 
 /obj/projectile/bullet/c45/ap
 	name = ".45 armor-piercing bullet"
+	damage = 0.9
 	armour_penetration = 50
 
 /obj/projectile/bullet/incendiary/c45
 	name = ".45 incendiary bullet"
-	damage = 15
+	damage = 0.7
 	fire_stacks = 2
 
 // 4.6x30mm (Autorifles)
 
 /obj/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
-	damage = 20
-	wound_bonus = -5
-	bare_wound_bonus = 5
+	damage = 1
 	embed_falloff_tile = -4
 
 /obj/projectile/bullet/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet"
-	damage = 15
+	damage = 0.9
 	armour_penetration = 40
 	embedding = null
 
 /obj/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
-	damage = 10
+	damage = 0.7
 	fire_stacks = 1

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -4,9 +4,7 @@
 	name =".50 bullet"
 	speed = 0.4
 	range = 400 // Enough to travel from one corner of the Z to the opposite corner and then some.
-	damage = 70
-	paralyze = 100
-	dismemberment = 50
+	damage = 1
 	armour_penetration = 50
 	var/breakthings = TRUE
 
@@ -33,25 +31,22 @@
 /obj/projectile/bullet/p50/penetrator
 	name = "penetrator round"
 	icon_state = "gauss"
-	damage = 60
+	damage = 0.8
 	range = 50
 	projectile_piercing = PASSMOB|PASSVEHICLE
 	projectile_phasing = ~(PASSMOB|PASSVEHICLE)
 	phasing_ignore_direct_target = TRUE
-	dismemberment = 0 //It goes through you cleanly.
-	paralyze = 0
 	breakthings = FALSE
 
 /obj/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety
 	icon_state = "gaussstrong"
-	damage = 25
+	damage = 10
 	speed = 0.3
 	range = 16
 
 /obj/projectile/bullet/p50/marksman
 	name = ".50 marksman round"
-	damage = 50
-	paralyze = 0
+	damage = 0.7
 	tracer_type = /obj/effect/projectile/tracer/sniper
 	impact_type = /obj/effect/projectile/impact/sniper
 	muzzle_type = /obj/effect/projectile/muzzle/sniper
@@ -77,6 +72,4 @@
 // scoundrel content
 /obj/projectile/bullet/p50/surplus
 	name ="surplus .50 bullet"
-	damage = 45
-	paralyze = 0
-	dismemberment = 0
+	damage = 0.5

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -72,4 +72,4 @@
 // scoundrel content
 /obj/projectile/bullet/p50/surplus
 	name ="surplus .50 bullet"
-	damage = 0.5
+	damage = 0.65

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -46,7 +46,7 @@
 /obj/projectile/bullet/marksman
 	name = "marksman nanoshot"
 	hitscan = TRUE
-	damage = 30
+	damage = 1
 	tracer_type = /obj/effect/projectile/tracer/solar
 	muzzle_type = /obj/effect/projectile/muzzle/bullet
 	impact_type = /obj/effect/projectile/impact/sniper
@@ -82,7 +82,7 @@
 	icon_state = "coinshot"
 	pixel_speed_multiplier = 0.333
 	speed = 1
-	damage = 5
+	damage = 1
 	color = "#dbdd4c"
 
 	/// Save the turf we're aiming for for future use

--- a/code/modules/projectiles/projectile/energy/decloner.dm
+++ b/code/modules/projectiles/projectile/energy/decloner.dm
@@ -1,7 +1,7 @@
 /obj/projectile/energy/declone
 	name = "radiation beam"
 	icon_state = "declone"
-	damage = 20
+	damage = 1
 	damage_type = CLONE
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 
@@ -15,5 +15,5 @@
 	..()
 
 /obj/projectile/energy/declone/weak
-	damage = 9
+	damage = 0.5
 	radiation_chance = 10

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,17 +1,18 @@
 /obj/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 15
+	damage = 0.5
 	damage_type = TOX
 	nodamage = FALSE
-	stamina = 60
-	eyeblur = 10
-	knockdown = 10
+	stamina = 0.5
+	knockdown = 1
 	slur = 10 SECONDS
+	armour_penetration = 100
 
 /obj/projectile/energy/bolt/halloween
 	name = "candy corn"
 	icon_state = "candy_corn"
 
 /obj/projectile/energy/bolt/large
-	damage = 20
+	damage = 0.5
+	stamina = 0.5

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -1,7 +1,7 @@
 /obj/projectile/energy/net
 	name = "energy netting"
 	icon_state = "e_netting"
-	damage = 10
+	damage = 0.2
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10

--- a/code/modules/projectiles/projectile/energy/ninja.dm
+++ b/code/modules/projectiles/projectile/energy/ninja.dm
@@ -1,7 +1,6 @@
 /obj/projectile/energy/dart //ninja throwing dart
 	name = "dart"
 	icon_state = "toxin"
-	damage = 5
+	damage = 1
 	damage_type = TOX
-	paralyze = 100
 	range = 7

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -2,7 +2,7 @@
 	name = "tesla bolt"
 	icon_state = "tesla_projectile"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
-	damage = 10 //A worse lasergun
+	damage = 1 //A worse lasergun
 	var/zap_flags = ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_LOW_POWER_GEN
 	var/zap_range = 3
 	var/power = 10000

--- a/code/modules/projectiles/projectile/energy/thermal.dm
+++ b/code/modules/projectiles/projectile/energy/thermal.dm
@@ -1,7 +1,7 @@
 /obj/projectile/energy/inferno
 	name = "molten nanite bullet"
 	icon_state = "infernoshot"
-	damage = 20
+	damage = 1
 	damage_type = BURN
 	armor_flag = ENERGY
 	armour_penetration = 10
@@ -26,7 +26,7 @@
 /obj/projectile/energy/cryo
 	name = "frozen nanite bullet"
 	icon_state = "cryoshot"
-	damage = 20
+	damage = 1
 	damage_type = BRUTE
 	armour_penetration = 10
 	armor_flag = ENERGY

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -574,7 +574,7 @@
 	trigger_range = 0
 	can_only_hit_target = TRUE
 	nodamage = FALSE
-	paralyze = 6 SECONDS
+	paralyze = 1 SECONDS
 	hitsound = 'sound/magic/mm_hit.ogg'
 
 	trail = TRUE

--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -41,4 +41,4 @@
 	base_icon_state = "foamdart_riot_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
 	nodamage = FALSE
-	stamina = 25
+	stamina = 1

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -119,7 +119,7 @@
 	custom_materials = list(/datum/material/iron = 10000, /datum/material/glass = 6000)
 	flags_1 = CONDUCT_1
 	item_flags = SURGICAL_TOOL
-	force = 15
+	force = 12
 	demolition_mod = 0.5
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("drills")
@@ -202,7 +202,7 @@
 	mob_throw_hit_sound = 'sound/weapons/pierce.ogg'
 	flags_1 = CONDUCT_1
 	item_flags = SURGICAL_TOOL
-	force = 15
+	force = 12
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 9
 	throw_speed = 2

--- a/scoundrel/code/game/objects/items/weapons/scoundrel_melee.dm
+++ b/scoundrel/code/game/objects/items/weapons/scoundrel_melee.dm
@@ -80,8 +80,8 @@
 
 	// combat stats
 	damtype = STAMINA
-	force = 18
-	throwforce = 18
+	force = 21
+	throwforce = 21
 	throw_speed = 2
 	throw_range = 10
 	armour_penetration = 40

--- a/scoundrel/code/modules/clothing/under/scoundrel_jumpsuits.dm
+++ b/scoundrel/code/modules/clothing/under/scoundrel_jumpsuits.dm
@@ -24,7 +24,7 @@
 	equip_delay_other = 80
 	limb_integrity = 30
 	armor = STARSUIT_ARMOR
-	clothing_flags = STOPSPRESSUREDAMAGE
+	clothing_flags = STOPSPRESSUREDAMAGE|PLASMAMAN_PREVENT_IGNITION
 	w_class = WEIGHT_CLASS_NORMAL
 //	slowdown = 0.5 need to figure out a better downside than this
 
@@ -50,7 +50,6 @@
 	icon_state = "starsuit"
 	worn_icon = 'scoundrel/icons/mob/clothing/scoundrel_head.dmi'
 	worn_icon_state = "starsuit"
-	
 	
 	flash_protect = 0
 	armor = STARSUIT_ARMOR

--- a/scoundrel/code/modules/clothing/under/scoundrel_jumpsuits.dm
+++ b/scoundrel/code/modules/clothing/under/scoundrel_jumpsuits.dm
@@ -23,7 +23,7 @@
 	strip_delay = 80
 	equip_delay_other = 80
 	limb_integrity = 30
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 50, FIRE = 0, ACID = 100, WOUND = 0)
+	armor = STARSUIT_ARMOR
 	clothing_flags = STOPSPRESSUREDAMAGE
 	w_class = WEIGHT_CLASS_NORMAL
 //	slowdown = 0.5 need to figure out a better downside than this
@@ -31,6 +31,11 @@
 	has_sensor = NO_SENSORS
 	random_sensor = FALSE
 	can_adjust = FALSE
+
+/obj/item/clothing/under/starsuit/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.space_suit_allowed
+	allowed += GLOB.generic_suit_allowed
 
 /obj/item/clothing/under/starsuit/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()
@@ -45,7 +50,10 @@
 	icon_state = "starsuit"
 	worn_icon = 'scoundrel/icons/mob/clothing/scoundrel_head.dmi'
 	worn_icon_state = "starsuit"
+	
+	
 	flash_protect = 0
+	armor = STARSUIT_ARMOR
 
 /obj/item/clothing/head/helmet/space/starsuit/engineer
 	name = "starsuit hardhat"
@@ -53,7 +61,7 @@
 	icon_state = "starsuit_hardhat"
 	worn_icon_state = "starsuit_hardhat"
 
-	armor = list(MELEE = 10, BULLET = 10, LASER = 10,ENERGY = 10, BOMB = 30, BIO = 100, FIRE = 80, ACID = 70)
+	armor = STARSUIT_HARDHAT_ARMOR
 
 /obj/item/clothing/head/helmet/space/starsuit/engineer/worn_overlays(mutable_appearance/standing, isinhands, icon_file)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Extensively touches up number balance on melee, guns and armor.
Codifies standard armor values with new defines in the combat.dm
Readouts for ballistic guns & armor vests have been improved and fixed up.

Also fixes a pretty significant issue with personal shields.
## Why It's Good For The Game
One of the big decisions made here was reducing the damage of projectiles to 1 as a baseline, give or take a few decimals. It's more of a coefficient for the weapons themselves to take advantage of, as all gameplay-relevant guns have been given a damage multiplier. Short of a considerable refactor (which is probably inevitable), this makes managing the expected damage output of a weapon much easier.
There are likely to be issues that arise from these changes, but we'll cross that bridge when we get there.

The use of armor defines will also make managing combat balance in-bulk much easier.
## Changelog
:cl:
add: Added new mechanics or gameplay changes
balance: armors rebalanced
balance: guns & projectiles rebalanced
balance: melee rebalanced
fix: gun readouts now use damage multipliers
fix: enabling a personalshield no longer changes the rules for all shields
/:cl:
