### PR TITLE
stops emp flashlights from emping turfs (a buff)

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -435,6 +435,8 @@
 	. = ..()
 	if(!proximity)
 		return
+	if(isturf(A))
+		return
 
 	if(emp_cur_charges > 0)
 		emp_cur_charges -= 1

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -435,7 +435,7 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(isturf(A))
+	if(isturf(A) && !istype(A, /turf/open/floor/light))
 		return
 
 	if(emp_cur_charges > 0)


### PR DESCRIPTION

## About The Pull Request

EMP Flashlights no longer attempt to EMP turfs.

## Why It's Good For The Game

This was pretty useless as far as features go, and just wastes charges.

## Changelog
:cl:
qol: EMP Flashlights no longer waste charges EMP'ing turfs that are unaffected.
/:cl:
