### PR TITLE
First aid tweaks

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -5,7 +5,7 @@
 	amount = 6
 	max_amount = 6
 	w_class = WEIGHT_CLASS_TINY
-	full_w_class = WEIGHT_CLASS_TINY
+	full_w_class = WEIGHT_CLASS_SMALL
 	throw_speed = 3
 	throw_range = 7
 	resistance_flags = FLAMMABLE
@@ -219,12 +219,12 @@
 	gender = PLURAL
 	singular_name = "suture"
 	icon_state = "suture"
-	self_delay = 3 SECONDS
-	other_delay = 1 SECONDS
-	amount = 10
-	max_amount = 10
+	self_delay = 1 SECONDS
+	other_delay = 0.5 SECONDS
+	amount = 20
+	max_amount = 20
 	repeating = TRUE
-	heal_brute = 10
+	heal_brute = 5
 	stop_bleeding = 0.6
 	grind_results = list(/datum/reagent/medicine/spaceacillin = 2)
 	merge_type = /obj/item/stack/medical/suture
@@ -233,22 +233,24 @@
 	name = "emergency suture"
 	desc = "A value pack of cheap sutures, not very good at repairing damage, but still decent at stopping bleeding."
 	heal_brute = 5
-	amount = 5
-	max_amount = 5
+	amount = 10
+	max_amount = 10
 	merge_type = /obj/item/stack/medical/suture/emergency
 
 /obj/item/stack/medical/suture/medicated
 	name = "medicated suture"
 	icon_state = "suture_purp"
 	desc = "A suture infused with drugs that speed up wound healing of the treated laceration."
-	heal_brute = 15
+	heal_brute = 10
+	amount = 10
+	max_amount = 20
 	stop_bleeding = 0.75
 	grind_results = list(/datum/reagent/medicine/polypyr = 1)
 	merge_type = /obj/item/stack/medical/suture/medicated
 
 /obj/item/stack/medical/ointment
 	name = "ointment"
-	desc = "Basic burn ointment, rated effective for second degree burns with proper bandaging, though it's still an effective stabilizer for worse burns. Not terribly good at outright healing burns though."
+	desc = "Basic burn ointment, rated effective for second degree burns with proper bandaging, though it's still an effective stabilizer for worse burns."
 	gender = PLURAL
 	singular_name = "ointment"
 	icon_state = "ointment"
@@ -256,10 +258,10 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	amount = 8
 	max_amount = 8
-	self_delay = 4 SECONDS
-	other_delay = 2 SECONDS
+	self_delay = 2 SECONDS
+	other_delay = 1 SECONDS
 
-	heal_burn = 5
+	heal_burn = 15
 	flesh_regeneration = 2.5
 	sanitization = 0.25
 	grind_results = list(/datum/reagent/medicine/c2/lenturi = 10)
@@ -275,11 +277,11 @@
 	gender = PLURAL
 	singular_name = "mesh piece"
 	icon_state = "regen_mesh"
-	self_delay = 3 SECONDS
-	other_delay = 1 SECONDS
-	amount = 15
-	heal_burn = 10
-	max_amount = 15
+	self_delay = 1 SECONDS
+	other_delay = 0.5 SECONDS
+	amount = 20
+	heal_burn = 5
+	max_amount = 20
 	repeating = TRUE
 	sanitization = 0.75
 	flesh_regeneration = 3
@@ -332,7 +334,9 @@
 
 	gender = PLURAL
 	icon_state = "aloe_mesh"
-	heal_burn = 15
+	amount = 10
+	max_amount = 20
+	heal_burn = 10
 	sanitization = 1.25
 	flesh_regeneration = 3.5
 	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
@@ -350,19 +354,19 @@
 	gender = PLURAL
 	singular_name = "aloe cream"
 	icon_state = "aloe_paste"
-	self_delay = 2 SECONDS
-	other_delay = 1 SECONDS
+	self_delay = 0.5 SECONDS
+	other_delay = 0.1 SECONDS
 	novariants = TRUE
 	amount = 20
 	max_amount = 20
 	repeating = TRUE
-	heal_brute = 3
-	heal_burn = 3
+	heal_brute = 2
+	heal_burn = 2
 	grind_results = list(/datum/reagent/consumable/aloejuice = 1)
 	merge_type = /obj/item/stack/medical/aloe
 
 /obj/item/stack/medical/aloe/fresh
-	amount = 2
+	amount = 4
 
 /obj/item/stack/medical/bone_gel
 	name = "bone gel"

--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -483,6 +483,7 @@
 	name = "smart chemical storage"
 	desc = "A refrigerated storage unit for medicine storage."
 	base_build_path = /obj/machinery/smartfridge/chemistry
+	use_power = FALSE
 
 /obj/machinery/smartfridge/chemistry/accept_check(obj/item/O)
 	var/static/list/chemfridge_typecache = typecacheof(list(
@@ -513,6 +514,8 @@
 
 /obj/machinery/smartfridge/chemistry/preloaded
 	initial_contents = list(
+		/obj/item/storage/pill_bottle/tritizine = 3,
+		/obj/item/reagent_containers/pill/tritizine = 6,
 		/obj/item/reagent_containers/pill/epinephrine = 12,
 		/obj/item/reagent_containers/pill/multiver = 5,
 		/obj/item/reagent_containers/cup/bottle/epinephrine = 1,

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -295,3 +295,11 @@
 	icon_state = "pill8"
 	list_reagents = list(/datum/reagent/iron = 30)
 	rename_with_volume = TRUE
+
+// scoundrel content
+/obj/item/reagent_containers/pill/tritizine
+	name = "tritizine pill"
+	desc = "A slow-acting treatment for minor injuries. Causes fatigue and has a low overdose threshold."
+	icon_state = "pill12"
+	list_reagents = list(/datum/reagent/medicine/tritizine = 5)
+	rename_with_volume = TRUE

--- a/scoundrel/code/game/objects/items/storage/medkit.dm
+++ b/scoundrel/code/game/objects/items/storage/medkit.dm
@@ -511,6 +511,16 @@
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/maintenance(src)
 
+// scoundrel content
+/obj/item/storage/pill_bottle/tritizine
+	name = "tritizine pillbottle"
+	desc = "Contains pills taken to quickly heal benign bruises and burns. Side effects include fatigue. WARNING: Do not take more than two within five minutes!"
+
+/obj/item/storage/pill_bottle/tritizine/PopulateContents()
+	for(var/i in 1 to 4)
+		new /obj/item/reagent_containers/pill/tritizine(src)
+// scoundrel content
+
 ///////////////////////////////////////// Psychologist inventory pillbottles
 /obj/item/storage/pill_bottle/happinesspsych
 	name = "happiness pills"

--- a/scoundrel/code/modules/cargo/packs/medical.dm
+++ b/scoundrel/code/modules/cargo/packs/medical.dm
@@ -174,3 +174,10 @@
 					/obj/item/clothing/mask/gas/plasmamask = 1,
 					/obj/item/tank/internals/plasmaman/belt/full = 1,)
 	goody = TRUE
+
+/datum/supply_pack/medical/tritizine_single
+	name = "(Single) Tritizine Pills"
+	desc = "A bottle of tritizine pills for treating benign injuries, like scrapes and bruises."
+	cost = CARGO_CRATE_VALUE * 0.25
+	contains = list(/obj/item/storage/pill_bottle/tritizine,)
+	goody = TRUE


### PR DESCRIPTION

## About The Pull Request
Changes sutures and meshes to be more granular, fast to user and with more charges, at the cost of less damage healed per charge. The heal per second is roughly the same, but you waste less fixing up minor injuries.

Also adds a new chem called tritizine that converts brute/burn/toxin damage to stamina at an extremely slow rate, useful for mending benign injuries like 5 brute damage. Not useful for combat. It has no recipe (yet) and can be found in the roundstart smartfridge + cargo.
## Why It's Good For The Game
## Changelog
:cl:
add: added tritizine
balance: meshes and sutures rebalanced to be more enjoyable and less wasteful
/:cl:
