### PR TITLE
Buffs the cost of deconstructing turfs, allows you to purchase RCDs, RPDs and plumbing constructors in cargo.

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -263,7 +263,7 @@
 			else
 				return list("mode" = RCD_AIRLOCK, "delay" = 50, "cost" = 16)
 		if(RCD_DECONSTRUCT)
-			return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 33)
+			return list("mode" = RCD_DECONSTRUCT, "delay" = 50, "cost" = 15)
 		if(RCD_WINDOWGRILLE)
 			return rcd_result_with_memory(
 				list("mode" = RCD_WINDOWGRILLE, "delay" = 1 SECONDS, "cost" = 4),

--- a/scoundrel/code/modules/cargo/packs/engineering_tools.dm
+++ b/scoundrel/code/modules/cargo/packs/engineering_tools.dm
@@ -27,7 +27,7 @@
 /datum/supply_pack/engineering/rcd
 	name = "Rapid Construction Device (RCD) Crate"
 	desc = "Rapid Construction Devices for rapidly constructing...things. And also deconstructiong them, but don't tell anyone!"
-	cost = CARGO_CRATE_VALUE * 7
+	cost = CARGO_CRATE_VALUE * 16
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/construction/rcd = 3)
 	crate_name = "rapid construction device crate"

--- a/scoundrel/code/modules/cargo/packs/engineering_tools.dm
+++ b/scoundrel/code/modules/cargo/packs/engineering_tools.dm
@@ -24,6 +24,33 @@
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
+/datum/supply_pack/engineering/rcd
+	name = "Rapid Construction Device (RCD) Crate"
+	desc = "Rapid Construction Devices for rapidly constructing...things. And also deconstructiong them, but don't tell anyone!"
+	cost = CARGO_CRATE_VALUE * 7
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/construction/rcd = 3)
+	crate_name = "rapid construction device crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engineering/rpd
+	name = "Rapid Pipe Dispenser (RPD) Crate"
+	desc = "For quickly and effecitvely laying pipes for all your gas transference needs!"
+	cost = CARGO_CRATE_VALUE * 7
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/pipe_dispenser = 3)
+	crate_name = "rapid pipe dispenser crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
+/datum/supply_pack/engineering/rpd
+	name = "Plumbing Constructor Crate"
+	desc = "For quickly and effecitvely putting down ugly plastic tubes for use in biochemical experiments and admixtures!"
+	cost = CARGO_CRATE_VALUE * 7
+	access_view = ACCESS_ENGINE_EQUIP
+	contains = list(/obj/item/construction/plumbing = 3)
+	crate_name = "plumbing constructor crate"
+	crate_type = /obj/structure/closet/crate/engineering/electrical
+
 /datum/supply_pack/tools/inducers
 	name = "NT-75 Electromagnetic Power Inducers Crate"
 	desc = "No rechargers? No problem, with the NT-75 EPI, you can recharge any standard \

--- a/scoundrel/code/modules/cargo/packs/engineering_tools.dm
+++ b/scoundrel/code/modules/cargo/packs/engineering_tools.dm
@@ -36,7 +36,7 @@
 /datum/supply_pack/engineering/rpd
 	name = "Rapid Pipe Dispenser (RPD) Crate"
 	desc = "For quickly and effecitvely laying pipes for all your gas transference needs!"
-	cost = CARGO_CRATE_VALUE * 7
+	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_ENGINE_EQUIP
 	contains = list(/obj/item/pipe_dispenser = 3)
 	crate_name = "rapid pipe dispenser crate"

--- a/scoundrel/code/modules/cargo/packs/engineering_tools.dm
+++ b/scoundrel/code/modules/cargo/packs/engineering_tools.dm
@@ -42,7 +42,7 @@
 	crate_name = "rapid pipe dispenser crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engineering/rpd
+/datum/supply_pack/engineering/plumbing_constructor
 	name = "Plumbing Constructor Crate"
 	desc = "For quickly and effecitvely putting down ugly plastic tubes for use in biochemical experiments and admixtures!"
 	cost = CARGO_CRATE_VALUE * 7


### PR DESCRIPTION

## About The Pull Request

Reduces the cost of deconstructing turfs.

Allows for the purchase of RCDs, RPDs and plumbing constructors.

## Why It's Good For The Game

These are fundamental tools for construction and building, and the easier to do it, the better.

## Changelog
:cl:
add: You can purchase RCDs, RPDs and plumbing constructors from cargo.
balance: Deconstructing turfs is much cheaper.
/:cl:
