### PR TITLE
Reintroduces adrenals.

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -12,6 +12,46 @@
 				<b>Function:</b> Allows operation of implant-locked weaponry, preventing equipment from falling into enemy hands."}
 	return dat
 
+/obj/item/implant/adrenalin
+	name = "adrenal implant"
+	desc = "Removes all stuns."
+	icon_state = "adrenal"
+	uses = 3
+
+/obj/item/implant/adrenalin/get_data()
+	var/dat = {"<b>Implant Specifications:</b><BR>
+				<b>Name:</b> Cybersun Industries Adrenaline Implant<BR>
+				<b>Life:</b> Five days.<BR>
+				<b>Important Notes:</b> <font color='red'>Illegal</font><BR>
+				<HR>
+				<b>Implant Details:</b> Subjects injected with implant can activate an injection of medical cocktails.<BR>
+				<b>Function:</b> Removes stuns, increases speed, and has a mild healing effect.<BR>
+				<b>Integrity:</b> Implant can only be used three times before reserves are depleted."}
+	return dat
+
+/obj/item/implant/adrenalin/activate()
+	. = ..()
+	uses--
+	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
+	imp_in.SetStun(0)
+	imp_in.SetKnockdown(0)
+	imp_in.SetUnconscious(0)
+	imp_in.SetParalyzed(0)
+	imp_in.SetImmobilized(0)
+	imp_in.adjustStaminaLoss(-75)
+	imp_in.set_resting(FALSE)
+	imp_in.update_mobility()
+
+	imp_in.reagents.add_reagent(/datum/reagent/medicine/synaptizine, 10)
+	imp_in.reagents.add_reagent(/datum/reagent/medicine/omnizine, 10)
+	imp_in.reagents.add_reagent(/datum/reagent/medicine/stimulants, 10)
+	if(!uses)
+		qdel(src)
+
+/obj/item/implanter/adrenalin
+	name = "implanter (adrenalin)"
+	imp_type = /obj/item/implant/adrenalin
+
 /obj/item/implant/emp
 	name = "emp implant"
 	desc = "Triggers an EMP."

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -18,6 +18,9 @@
 	icon_state = "adrenal"
 	uses = 3
 
+/obj/item/implant/adrenalin/single
+	uses = 1
+
 /obj/item/implant/adrenalin/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Cybersun Industries Adrenaline Implant<BR>
@@ -33,23 +36,34 @@
 	. = ..()
 	uses--
 	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
+	playsound(loc, 'sound/scoundrel/shield/beepbeep.ogg', 15, FALSE)
 	imp_in.SetStun(0)
 	imp_in.SetKnockdown(0)
 	imp_in.SetUnconscious(0)
 	imp_in.SetParalyzed(0)
 	imp_in.SetImmobilized(0)
-	imp_in.adjustStaminaLoss(-75)
+
+	imp_in.adjustStaminaLoss(-100)
+	imp_in.adjustBruteLoss(-10)
+	imp_in.adjustFireLoss(-10)
+	imp_in.adjustToxLoss(-10)
+	imp_in.adjustOxyLoss(-10)
+
 	imp_in.set_resting(FALSE)
 
-	imp_in.reagents.add_reagent(/datum/reagent/medicine/synaptizine, 10)
+	imp_in.reagents.add_reagent(/datum/reagent/medicine/ephedrine, 5)
 	imp_in.reagents.add_reagent(/datum/reagent/medicine/omnizine, 10)
-	imp_in.reagents.add_reagent(/datum/reagent/medicine/stimulants, 10)
+	imp_in.reagents.add_reagent(/datum/reagent/pax, 1)
 	if(!uses)
+		to_chat(imp_in, "<span class='notice'>You feel a faint electrical buzz as you use up the last adrenal!</span>")
 		qdel(src)
 
 /obj/item/implanter/adrenalin
 	name = "implanter (adrenalin)"
 	imp_type = /obj/item/implant/adrenalin
+
+/obj/item/implanter/adrenalin/single
+	imp_type = /obj/item/implant/adrenalin/single
 
 /obj/item/implant/emp
 	name = "emp implant"

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -40,7 +40,6 @@
 	imp_in.SetImmobilized(0)
 	imp_in.adjustStaminaLoss(-75)
 	imp_in.set_resting(FALSE)
-	imp_in.update_mobility()
 
 	imp_in.reagents.add_reagent(/datum/reagent/medicine/synaptizine, 10)
 	imp_in.reagents.add_reagent(/datum/reagent/medicine/omnizine, 10)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -370,6 +370,12 @@
 /obj/item/storage/box/syndie_kit/imp_adrenal/PopulateContents()
 	new /obj/item/implanter/adrenalin(src)
 
+/obj/item/storage/box/syndie_kit/imp_adrenal/single
+	name = "adrenal implant box"
+
+/obj/item/storage/box/syndie_kit/imp_adrenal/single/PopulateContents()
+	new /obj/item/implanter/adrenalin/single(src)
+
 /obj/item/storage/box/syndie_kit/imp_storage
 	name = "storage implant box"
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -364,6 +364,12 @@
 	for(var/i in 1 to 7)
 		new /obj/item/firing_pin/clown/ultra(src)
 
+/obj/item/storage/box/syndie_kit/imp_adrenal
+	name = "adrenal implant box"
+
+/obj/item/storage/box/syndie_kit/imp_adrenal/PopulateContents()
+	new /obj/item/implanter/adrenalin(src)
+
 /obj/item/storage/box/syndie_kit/imp_storage
 	name = "storage implant box"
 

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -14,7 +14,6 @@
 	name = "Adrenal Implant"
 	desc = "An implant injected into the body, and later activated at the user's will. It will inject a chemical \
 			cocktail which removes all incapacitating effects, lets the user run faster and has a mild healing effect."
-			cocktail which lets you push yourself harder to get out of sticky situations. Avoid large doses if possible."
 	item = /obj/item/storage/box/syndie_kit/imp_adrenal
 	cost = 8
 

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -12,10 +12,17 @@
 // No progression cost
 /datum/uplink_item/implants/adrenal
 	name = "Adrenal Implant"
-	desc = "An implant injected into the body, and later activated at the user's will. It will inject a chemical \
-			cocktail which removes all incapacitating effects, lets the user run faster and has a mild healing effect."
+	desc = "An implant injected into the body, and later activated at the user's will. It will increase user speed, \
+	reduce fatigue buildup, and mend a small amount of physical damage. Side effects include a brief period of \
+	pathological nonviolence, and overdose can be lethal. Has three charges."
 	item = /obj/item/storage/box/syndie_kit/imp_adrenal
-	cost = 8
+	cost = 10
+
+/datum/uplink_item/implants/adrenal/single
+	name = "Budget Adrenal Implant"
+	desc = "An adrenal implant with a single charge, an emergency get-out-of-jail card for agents of all expertise."
+	item = /obj/item/storage/box/syndie_kit/imp_adrenal/single
+	cost = 4
 
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"

--- a/code/modules/uplink/uplink_items/implant.dm
+++ b/code/modules/uplink/uplink_items/implant.dm
@@ -10,6 +10,14 @@
 	surplus = 50
 
 // No progression cost
+/datum/uplink_item/implants/adrenal
+	name = "Adrenal Implant"
+	desc = "An implant injected into the body, and later activated at the user's will. It will inject a chemical \
+			cocktail which removes all incapacitating effects, lets the user run faster and has a mild healing effect."
+			cocktail which lets you push yourself harder to get out of sticky situations. Avoid large doses if possible."
+	item = /obj/item/storage/box/syndie_kit/imp_adrenal
+	cost = 8
+
 /datum/uplink_item/implants/freedom
 	name = "Freedom Implant"
 	desc = "An implant injected into the body and later activated at the user's will. It will attempt to free the \


### PR DESCRIPTION

## About The Pull Request

Re-adds adrenal implant, and associated effect.

## Why It's Good For The Game

I think having more opportunities to make it back up is important. I really disliked how the removal of adrenals ostensibly opened up tots to getting owned by one-shots and similar attacks. This, hopefully, keeps them from simply being geeked without recourse.

## Changelog
:cl:
add: Reintroduces adrenals.
/:cl:
