### PR TITLE
Disables Progression Traitors

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -75,15 +75,12 @@
 			purchase_log = new(owner, src)
 	src.lockable = lockable
 	src.active = enabled
-	if(!uplink_handler_override)
-		uplink_handler = new()
-		uplink_handler.has_objectives = FALSE
-		uplink_handler.uplink_flag = uplink_flag
-		uplink_handler.telecrystals = starting_tc
-		uplink_handler.has_progression = has_progression
-		uplink_handler.purchase_log = purchase_log
-	else
-		uplink_handler = uplink_handler_override
+	uplink_handler = new()
+	uplink_handler.has_objectives = FALSE
+	uplink_handler.uplink_flag = uplink_flag
+	uplink_handler.telecrystals = starting_tc
+	uplink_handler.has_progression = has_progression
+	uplink_handler.purchase_log = purchase_log
 	RegisterSignal(uplink_handler, COMSIG_UPLINK_HANDLER_ON_UPDATE, PROC_REF(handle_uplink_handler_update))
 	if(!lockable)
 		active = TRUE

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -562,7 +562,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 GLOBAL_LIST_EMPTY(possible_items)
 /datum/objective/steal
 	name = "steal"
-	martyr_compatible = FALSE
+	martyr_compatible = TRUE
 	admin_grantable = TRUE
 	var/datum/objective_item/targetinfo = null //Save the chosen item datum so we can access it later.
 	var/obj/item/steal_target = null //Needed for custom objectives (they're just items, not datums).

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -203,20 +203,54 @@
 /datum/antagonist/traitor/proc/forge_traitor_objectives()
 	objectives.Cut()
 
-	var/datum/objective/traitor_progression/final_objective = new /datum/objective/traitor_progression()
+/*	var/datum/objective/traitor_progression/final_objective = new /datum/objective/traitor_progression()
 	final_objective.owner = owner
-	objectives += final_objective
+	objectives += final_objective */
 
-	var/datum/objective/traitor_objectives/objective_completion = new /datum/objective/traitor_objectives()
+/*	var/datum/objective/traitor_objectives/objective_completion = new /datum/objective/traitor_objectives()
 	objective_completion.owner = owner
-	objectives += objective_completion
+	objectives += objective_completion */
+
+	switch(rand(1,100))
+		if(1 to 30)
+			var/datum/objective/assassinate/kill_objective = new
+			kill_objective.owner = owner
+			kill_objective.find_target()
+			objectives += kill_objective
+
+			var/datum/objective/assassinate/kill_objective_2 = new
+			kill_objective_2.owner = owner
+			kill_objective_2.find_target()
+			objectives += kill_objective_2
+
+		if(31 to 60)
+			var/datum/objective/steal/steal_objective = new
+			steal_objective.owner = owner
+			steal_objective.find_target()
+			objectives += steal_objective
+
+			var/datum/objective/steal/steal_objective_2 = new
+			steal_objective_2.owner = owner
+			steal_objective_2.find_target()
+			objectives += steal_objective_2
+
+		if(61 to 85)
+			var/datum/objective/assassinate/kill_objective = new
+			kill_objective.owner = owner
+			kill_objective.find_target()
+			objectives += kill_objective
+
+			var/datum/objective/steal/steal_objective = new
+			steal_objective.owner = owner
+			steal_objective.find_target()
+			objectives += steal_objective
 
 	var/datum/objective/objective_escape
 	var/random_escape = pick_weight(list(
-		/datum/objective/escape = 85,
-		/datum/objective/hijack = 10,
-		/datum/objective/survive = 4,
-		/datum/objective/martyr = 1
+		/datum/objective/escape = 50,
+		/datum/objective/hijack = 15,
+		/datum/objective/survive = 25,
+		/datum/objective/martyr = 10,
 	))
 	objective_escape = new random_escape()
 	objective_escape.owner = owner

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -212,7 +212,7 @@
 	objectives += objective_completion */
 
 	switch(rand(1,100))
-		if(1 to 30)
+		if(1 to 32)
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()
@@ -223,7 +223,7 @@
 			kill_objective_2.find_target()
 			objectives += kill_objective_2
 
-		if(31 to 60)
+		if(33 to 65)
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = owner
 			steal_objective.find_target()
@@ -234,7 +234,7 @@
 			steal_objective_2.find_target()
 			objectives += steal_objective_2
 
-		if(61 to 85)
+		if(66 to 100)
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = owner
 			kill_objective.find_target()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -47,14 +47,13 @@
 			uplink.uplink_handler = uplink_handler
 		else
 			uplink_handler = uplink.uplink_handler
-		uplink_handler.has_progression = TRUE
+		uplink_handler.has_progression = FALSE
 		SStraitor.register_uplink_handler(uplink_handler)
 
-		uplink_handler.has_objectives = TRUE
+		uplink_handler.has_objectives = FALSE
 		uplink_handler.generate_objectives()
 
-		if(uplink_handler.progression_points < SStraitor.current_global_progression)
-			uplink_handler.progression_points = SStraitor.current_global_progression * SStraitor.newjoin_progression_coeff
+		uplink_handler.progression_points = 500
 
 		var/list/uplink_items = list()
 		for(var/datum/uplink_item/item as anything in SStraitor.uplink_items)


### PR DESCRIPTION
## About The Pull Request
Disables the mechanics that intercept and modify the uplink to support prog-traitor.
Relevant objectives have been commented out and replaced.

## Why It's Good For The Game
"It was stressful, unfun, impossible to balance and non-conducive to creativity. It doesn't encourage anything we want players to be doing. Good riddance." - psytc
## Changelog
:cl:
Add: replaced progress objectives with classic steal and assassinate objectives
Add: theft objectives are now compatible with martyr objectives
Remove: Removes progression from traitors. They start with full access to their uplink, but the same 20 TC restriction.
/:cl:
