### PR TITLE
Parallax runtime patch

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -199,10 +199,10 @@
 	back = /obj/item/storage/backpack/satchel/fireproof
 	suit = /obj/item/clothing/suit/hooded/hardsuit/syndicate
 
-/datum/outfit/nuclear_operative/post_equip(mob/living/carbon/human/H, visualsOnly)
-	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
-	booster.active = TRUE
-	H.update_worn_back()
+///datum/outfit/nuclear_operative/post_equip(mob/living/carbon/human/H, visualsOnly)
+//	var/obj/item/mod/module/armor_booster/booster = locate() in H.back
+//	booster.active = TRUE
+//	H.update_worn_back()
 
 /datum/outfit/nuclear_operative_elite
 	name = "Nuclear Operative (Elite, Preview only)"


### PR DESCRIPTION
## About The Pull Request
Slaps a bandaid over a persistent issue with the parallax that would otherwise cause aggressive dividebyzero runtimes.
This isn't the ideal solution by a stretch, but anything more complex seems at the moment beyond my skill level, and the mechanics being circumvented aren't being used in any way right now.

Also fixes a minor, unrelated issue with a syndicate operative outfit.
## Why It's Good For The Game
## Changelog
:cl:
fix: patched parallax runtime
fix: runtime on operative outfit spawn
/:cl:
