### PR TITLE
adds coffee to the adrenal implant and stimulent medipen

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -53,6 +53,7 @@
 
 	imp_in.reagents.add_reagent(/datum/reagent/medicine/ephedrine, 5)
 	imp_in.reagents.add_reagent(/datum/reagent/medicine/omnizine, 10)
+	imp_in.reagents.add_reagent(/datum/reagent/consumable/coffee, 10)
 	imp_in.reagents.add_reagent(/datum/reagent/pax, 1)
 	if(!uses)
 		to_chat(imp_in, "<span class='notice'>You feel a faint electrical buzz as you use up the last adrenal!</span>")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -167,13 +167,14 @@
 
 /obj/item/reagent_containers/hypospray/medipen/stimulants
 	name = "stimulant medipen"
-	desc = "Contains a very large amount of an incredibly powerful stimulant, vastly increasing your movement speed and reducing stuns by a very large amount for around five minutes. Do not take if pregnant."
+	desc = "Contains a very large amount of an incredibly powerful stimulant, vastly increasing your movement speed and reducing stuns by a very large amount for around five minutes.\
+	Also includes a little bit of coffee to perk you up a little. Do not take if pregnant."
 	icon_state = "syndipen"
 	inhand_icon_state = "tbpen"
 	base_icon_state = "syndipen"
-	volume = 50
-	amount_per_transfer_from_this = 50
-	list_reagents = list(/datum/reagent/medicine/stimulants = 50)
+	volume = 60
+	amount_per_transfer_from_this = 60
+	list_reagents = list(/datum/reagent/medicine/stimulants = 50, /datum/reagent/consumable/coffee = 10)
 
 /obj/item/reagent_containers/hypospray/medipen/morphine
 	name = "morphine medipen"


### PR DESCRIPTION

## About The Pull Request

Adds a little bit of coffee into your adrenals and stimpacks.

## Why It's Good For The Game

These help combat tired sleepy agents taking a nap mid-combat.

![FnNss08WQAAV2eP](https://user-images.githubusercontent.com/40847847/214237661-9f3025f5-555c-483a-b884-0760c69e0837.png)

## Changelog
:cl:
add: Adds coffee to the stimulant injectors; adrenals and stimpack medipens.
/:cl:
