### PR TITLE
Acting captain replacement

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -41,13 +41,12 @@ SUBSYSTEM_DEF(job)
 	 * See [/datum/controller/subsystem/ticker/proc/equip_characters]
 	 */
 	var/list/chain_of_command = list(
-		JOB_CAPTAIN = 1,
-		JOB_HEAD_OF_PERSONNEL = 2,
-		JOB_RESEARCH_DIRECTOR = 3,
-		JOB_CHIEF_ENGINEER = 4,
-		JOB_CHIEF_MEDICAL_OFFICER = 5,
-		JOB_HEAD_OF_SECURITY = 6,
-		JOB_QUARTERMASTER = 7,
+		JOB_QUARTERMASTER_SCOUNDREL = 1,
+		JOB_CAPTAIN_SCOUNDREL = 2,
+		JOB_DETECTIVE_SCOUNDREL = 3,
+		JOB_MEDSCI_SPECIALIST = 4,
+		JOB_ENGINEERING_SPECIALIST = 5,
+		JOB_DECKHAND = 6,
 	)
 
 	/// If TRUE, some player has been assigned Captaincy or Acting Captaincy at some point during the shift and has been given the spare ID safe code.
@@ -1010,7 +1009,7 @@ SUBSYSTEM_DEF(job)
 	if(!id_safe_code)
 		CRASH("Cannot promote [new_captain.real_name] to Captain, there is no id_safe_code.")
 
-	var/paper = new /obj/item/paper/fluff/spare_id_safe_code()
+	var/paper = new /obj/item/storage/pouch/holding/leadership()
 	var/list/slots = list(
 		LOCATION_LPOCKET = ITEM_SLOT_LPOCKET,
 		LOCATION_RPOCKET = ITEM_SLOT_RPOCKET,
@@ -1020,22 +1019,23 @@ SUBSYSTEM_DEF(job)
 	var/where = new_captain.equip_in_one_of_slots(paper, slots, FALSE) || "at your feet"
 
 	if(acting_captain)
-		to_chat(new_captain, span_notice("Due to your position in the chain of command, you have been promoted to Acting Captain. You can find in important note about this [where]."))
+		to_chat(new_captain, span_notice("Because of your conduct and standing with the crew, you've been entrusted with some leadership essentials. They can be found [where]."))
 	else
-		to_chat(new_captain, span_notice("You can find the code to obtain your spare ID from the secure safe on the Bridge [where]."))
+		to_chat(new_captain, span_notice("Because of your conduct and standing with the crew, you've been entrusted with some leadership essentials. They can be found [where]."))
 
 	// Force-give their ID card bridge access.
-	var/obj/item/id_slot = new_captain.get_item_by_slot(ITEM_SLOT_ID)
+	// Commented out as of adding the spare leadership ID, jan 2023
+/*	var/obj/item/id_slot = new_captain.get_item_by_slot(ITEM_SLOT_ID)
 	if(id_slot)
 		var/obj/item/card/id/id_card = id_slot.GetID()
 		if(!(ACCESS_COMMAND in id_card.access))
-			id_card.add_wildcards(list(ACCESS_COMMAND), mode=FORCE_ADD_ALL)
+			id_card.add_wildcards(list(ACCESS_COMMAND), mode=FORCE_ADD_ALL)*/
 
 	assigned_captain = TRUE
 
 /// Send a drop pod containing a piece of paper with the spare ID safe code to loc
 /datum/controller/subsystem/job/proc/send_spare_id_safe_code(loc)
-	new /obj/effect/pod_landingzone(loc, /obj/structure/closet/supplypod/centcompod, new /obj/item/paper/fluff/emergency_spare_id_safe_code())
+	new /obj/effect/pod_landingzone(loc, /obj/structure/closet/supplypod/centcompod, new /obj/item/storage/pouch/holding/leadership())
 	safe_code_timer_id = null
 	safe_code_request_loc = null
 

--- a/code/datums/id_trim/scoundrel_trim.dm
+++ b/code/datums/id_trim/scoundrel_trim.dm
@@ -196,7 +196,8 @@
 		ACCESS_HYDROPONICS,
 		//basic access end
 		ACCESS_DETECTIVE,
-		ACCESS_COMMAND
+		ACCESS_COMMAND,
+		ACCESS_ENGINE_EQUIP,
 		)
 	job = null
 

--- a/code/datums/id_trim/scoundrel_trim.dm
+++ b/code/datums/id_trim/scoundrel_trim.dm
@@ -174,3 +174,40 @@
 		ACCESS_COMMAND
 		)
 	job = /datum/job/detective_scoundrel
+
+/datum/id_trim/job/deckhand/leader
+	assignment = "Leader"
+	trim_state = "trim_headofpersonnel"
+	orbit_icon = "toolbox"
+	department_color = COLOR_MAROON
+	subdepartment_color = COLOR_MAROON
+	sechud_icon_state = SECHUD_HEAD_OF_PERSONNEL
+	minimal_access = list(
+		ACCESS_MAINT_TUNNELS,
+		ACCESS_CARGO,
+		ACCESS_ATMOSPHERICS,
+		ACCESS_KITCHEN,
+		ACCESS_PHARMACY,
+		ACCESS_SURGERY,
+		ACCESS_KEYCARD_AUTH,
+		ACCESS_MINING,
+		ACCESS_MINING_STATION,
+		ACCESS_ROBOTICS,
+		ACCESS_HYDROPONICS,
+		//basic access end
+		ACCESS_DETECTIVE,
+		ACCESS_COMMAND
+		)
+	job = null
+
+/datum/id_trim/job/master
+	assignment = "Leader"
+	trim_state = "trim_captain"
+	orbit_icon = "crown"
+	department_color = COLOR_MAROON
+	subdepartment_color = COLOR_MAROON
+	sechud_icon_state = SECHUD_CAPTAIN
+	template_access = list(
+		ACCESS_CAPTAIN,
+		ACCESS_CHANGE_IDS,
+		)

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1069,10 +1069,10 @@
 	ADD_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD, ROUNDSTART_TRAIT)
 
 /obj/item/card/id/advanced/gold/captains_spare
-	name = "captain's spare ID"
-	desc = "The spare ID of the High Lord himself."
-	registered_name = "Captain"
-	trim = /datum/id_trim/job/captain
+	name = "master ID"
+	desc = "This'll get you anywhere you need to go on the station."
+//	registered_name = "Captain"
+	trim = /datum/id_trim/job/master
 	registered_age = null
 
 /obj/item/card/id/advanced/gold/captains_spare/update_label() //so it doesn't change to Captain's ID card (Captain) on a sneeze
@@ -1635,6 +1635,13 @@
 	name = "Green Team identification card"
 	desc = "A card used to identify members of the green team for CTF"
 	icon_state = "ctf_green"
+
+// scoundrel content
+/obj/item/card/id/advanced/silver/leader_spare
+	name = "spare leadership ID"
+	desc = "A spare ID providing access to the station's sensitive areas."
+	trim = /datum/id_trim/job/deckhand/leader
+	registered_age = null
 
 #undef INTERN_THRESHOLD_FALLBACK_HOURS
 #undef ID_ICON_BORDERS

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -399,7 +399,7 @@
 
 
 /datum/job/proc/get_captaincy_announcement(mob/living/captain)
-	return "Due to extreme staffing shortages, newly promoted Acting Captain [captain.real_name] on deck!"
+	return "[captain.real_name] has been entrusted with leadership in the absence of a Quartermaster or Captain!"
 
 
 /// Returns an atom where the mob should spawn in.

--- a/code/modules/jobs/job_types/scoundrel_jobs.dm
+++ b/code/modules/jobs/job_types/scoundrel_jobs.dm
@@ -263,6 +263,9 @@
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_BOLD_SELECT_TEXT | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS
 	rpg_title = "Shipmaster"
 
+/datum/job/captain_scoundrel/get_captaincy_announcement(mob/living/captain)
+	return
+
 /datum/outfit/job/captain_scoundrel
 	name = "Captain"
 	jobtype = /datum/job/captain_scoundrel
@@ -340,6 +343,9 @@
 	job_flags = JOB_ANNOUNCE_ARRIVAL | JOB_CREW_MANIFEST | JOB_EQUIP_RANK | JOB_CREW_MEMBER | JOB_NEW_PLAYER_JOINABLE | JOB_BOLD_SELECT_TEXT | JOB_REOPEN_ON_ROUNDSTART_LOSS | JOB_ASSIGN_QUIRKS
 	ignore_human_authority = TRUE
 
+/datum/job/quartermaster_scoundrel/get_captaincy_announcement(mob/living/captain)
+	return
+
 /datum/outfit/job/quartermaster_scoundrel
 	name = "Quartermaster"
 	jobtype = /datum/job/quartermaster_scoundrel
@@ -364,7 +370,7 @@
 	suit_store = /obj/item/personalshield/standard/advanced
 
 	l_pocket = /obj/item/modular_computer/tablet/pda/deckhand/leader/quartermaster
-	r_pocket = /obj/item/storage/pouch/holding // move this to the locker when it becomes a steal obj
+//	r_pocket = /obj/item/storage/pouch/holding // moved to acting captain system
 
 	pda_slot = ITEM_SLOT_LPOCKET
 

--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -196,6 +196,12 @@
 	atom_storage.max_slots = 7
 	atom_storage.max_total_storage = 20
 
+/obj/item/storage/pouch/holding/leadership/PopulateContents()
+	new /obj/item/card/id/advanced/silver/leader_spare(src)
+	new /obj/item/clothing/neck/stethoscope(src)
+	new /obj/item/door_remote/captain(src)
+	new /obj/item/paper/fluff/leadership_assignment(src)
+
 //traitor
 /obj/item/storage/pouch/traitor
 	name = "suspicious pouch"

--- a/scoundrel/code/modules/mapfluff/alibi.dm
+++ b/scoundrel/code/modules/mapfluff/alibi.dm
@@ -66,8 +66,8 @@
 /obj/item/paper/fluff/leadership_assignment
 	name = "\proper your responsibility"
 	default_raw_text = "\
-	You have been entrusted with a spare leadership ID to be used \
-	in an emergency. The crew is depending on you to \
+	You have been entrusted with a spare leadership ID, granting access to the bridge and the \
+	detective's office. The crew is depending on you to \
 	make the right call with it. No one having bridge access in an emergency can be as dangerous as \
 	letting it fall into the wrong hands. <br><br> \
 	\

--- a/scoundrel/code/modules/mapfluff/alibi.dm
+++ b/scoundrel/code/modules/mapfluff/alibi.dm
@@ -1,3 +1,5 @@
+// rename this file to generic fluff
+
 /obj/item/paper/fluff/alibipouch
 	name = "\proper alibi instructions"
 	default_raw_text = "Life as an independent on the frontier means looking out for yourself \
@@ -60,3 +62,14 @@
 	KNOCKOUT <br>\
 	5u Sodium Thiopental <br>\
 	10u Fentanyl <br><br>"
+
+/obj/item/paper/fluff/leadership_assignment
+	name = "\proper your responsibility"
+	default_raw_text = "\
+	You have been entrusted with a spare leadership ID to be used \
+	in an emergency. The crew is depending on you to \
+	make the right call with it. No one having bridge access in an emergency can be as dangerous as \
+	letting it fall into the wrong hands. <br><br> \
+	\
+	Additionally, you've been provided a command remote and a stethoscope to extract the master keycard \
+	from the vault's safe, if necessary."


### PR DESCRIPTION

## About The Pull Request
This replaces the mechanics surrounding acting captains. Acting captains now get the unique pouch of holding, loaded with a spare leadership ID, stethoscope, command remote, and instructions on how to extract the master ID from the vault.

This doesn't actually pull out the subsystem, so the spare ID safe and code can still technically generate. I don't expect this to be necessary for anything and should probably be removed at some point.
## Why It's Good For The Game
Better mechanics, and more thematically in-line
## Changelog
:cl:
add: added leader ID, provided to whoever is chosen to be leader
add: captain's spare reflavored to master ID
del: QM no longer gets the pouch of holding assigned in their outfit
balance: acting captaincy replaced with entrusted leadership
/:cl:
