### PR TITLE
Misc stuff 5

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -29,10 +29,11 @@
 	var/cleanspeed = 3.5 SECONDS //slower than mop
 	force_string = "robust... against germs"
 	var/uses = 50
+	var/sliptime = 40
 
 /obj/item/soap/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/slippery, 80)
+	AddComponent(/datum/component/slippery, sliptime)
 	AddComponent(/datum/component/cleaner, cleanspeed, 0.1, pre_clean_callback=CALLBACK(src, PROC_REF(should_clean)), on_cleaned_callback=CALLBACK(src, PROC_REF(decreaseUses))) //less scaling for soapies
 
 /obj/item/soap/examine(mob/user)
@@ -60,7 +61,7 @@
 	icon_state = "soapgibs"
 	inhand_icon_state = "soapgibs"
 	worn_icon_state = "soapgibs"
-	cleanspeed = 3 SECONDS // faster than base soap to reward chemists for going to the effort
+	cleanspeed = 2 SECONDS // faster than base soap to reward chemists for going to the effort
 
 /obj/item/soap/nanotrasen
 	desc = "A heavy duty bar of Nanotrasen brand soap. Smells of plasma."
@@ -68,7 +69,7 @@
 	icon_state = "soapnt"
 	inhand_icon_state = "soapnt"
 	worn_icon_state = "soapnt"
-	cleanspeed = 2.8 SECONDS //janitor gets this
+	cleanspeed = 2 SECONDS //janitor gets this
 //	uses = 300
 
 /obj/item/soap/nanotrasen/cyborg
@@ -88,6 +89,7 @@
 	inhand_icon_state = "soapsyndie"
 	worn_icon_state = "soapsyndie"
 	cleanspeed = 0.5 SECONDS //faster than mops so it's useful for traitors who want to clean crime scenes
+	sliptime = 80
 
 /obj/item/soap/omega
 	name = "\improper Omega soap"
@@ -98,6 +100,7 @@
 	worn_icon_state = "soapomega"
 	cleanspeed = 0.3 SECONDS //Only the truest of mind soul and body get one of these
 	uses = 800 //In the Greek numeric system, Omega has a value of 800
+	sliptime = 80
 
 /obj/item/soap/omega/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is using [src] to scrub themselves from the timeline! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -126,7 +126,7 @@
 	gender = PLURAL
 	singular_name = "medical gauze"
 	icon_state = "gauze"
-	self_delay = 5 SECONDS
+	self_delay = 2 SECONDS
 	other_delay = 2 SECONDS
 	max_amount = 12
 	amount = 6
@@ -197,8 +197,8 @@
 	name = "improvised gauze"
 	singular_name = "improvised gauze"
 	desc = "A roll of cloth roughly cut from something that does a decent job of stabilizing wounds, but less efficiently so than real medical gauze."
-	self_delay = 6 SECONDS
-	other_delay = 3 SECONDS
+	self_delay = 4 SECONDS
+	other_delay = 2 SECONDS
 	splint_factor = 0.85
 	burn_cleanliness_bonus = 0.7
 	absorption_rate = 0.075

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -567,6 +567,7 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 		new /datum/stack_recipe("medipen box", /obj/item/storage/box/medipens), \
 		new /datum/stack_recipe("oxygen tank box", /obj/item/storage/box/emergencytank), \
 		new /datum/stack_recipe("extended oxygen tank box", /obj/item/storage/box/engitank), \
+		new /datum/stack_recipe("suspicious box", /obj/item/storage/box/syndie_kit), \
 		null, \
 
 		new /datum/stack_recipe("survival box", /obj/item/storage/box/survival/crafted), \

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -172,6 +172,10 @@
 	is_open = TRUE
 	contents_tag = "candle"
 
+/obj/item/storage/fancy/candle_box/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
+
 /obj/item/storage/fancy/candle_box/attack_self(mob/user)
 	if(!contents.len)
 		new fold_result(user.drop_location())

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -368,13 +368,18 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	C.setDir(user.dir)
 	qdel(src)
 
-/obj/item/chair/proc/smash(mob/living/user)
+/obj/item/chair/proc/smash(mob/living/target_mob)
+	var/mob/living/carbon/C = target_mob
+	if(C.get_active_held_item() == src)
+		return
+	C.visible_message(span_danger("[src] smashes to pieces against \the [C]"))
+	if(iscarbon(C))
+		C.Knockdown(0.1)
 	var/stack_type = initial(origin_type.buildstacktype)
 	playsound(loc, chairsmash_sound, 30, TRUE, -2)
 	if(!stack_type)
 		return
 	var/remaining_mats = initial(origin_type.buildstackamount)
-//	remaining_mats-- //Part of the chair was rendered completely unusable. It magically dissapears. Maybe make some dirt?
 	if(remaining_mats)
 		for(var/M=1 to remaining_mats)
 			new stack_type(get_turf(loc))
@@ -382,37 +387,21 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 		new /obj/item/stack/rods(get_turf(loc), 2)
 	qdel(src)
 
-
-
-
 /obj/item/chair/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == UNARMED_ATTACK && prob(hit_reaction_chance))
 		owner.visible_message(span_danger("[owner] fends off [attack_text] with [src]!"))
 		return TRUE
 	return FALSE
 
-/obj/item/chair/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/chair/attack(mob/living/target_mob, mob/living/user, params)
 	. = ..()
-	if(!proximity)
-		return
-	if(!ismob(target))
-		return
-
-	user.visible_message(span_danger("[user] smashes \the [src] to pieces against \the [target]"))
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		C.Knockdown(0.1)
-	smash(user)
+	var/C = target_mob
+	smash(C)
 
 /obj/item/chair/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
-	if(!ismob(hit_atom))
-		return
-	hit_atom.visible_message(span_danger("[src] smashes to pieces against \the [hit_atom]"))
-	if(iscarbon(hit_atom))
-		var/mob/living/carbon/C = hit_atom
-		C.Knockdown(0.1)
-	smash()
+	var/C = hit_atom
+	smash(C)
 
 /obj/item/chair/greyscale
 	material_flags = MATERIAL_EFFECTS | MATERIAL_ADD_PREFIX | MATERIAL_COLOR | MATERIAL_AFFECT_STATISTICS

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -285,7 +285,7 @@
 		broken = TRUE
 		rods_amount = 1
 		rods_broken = FALSE
-		var/obj/R = new rods_type(drop_location(), rods_broken)
+		var/obj/R = new rods_type(drop_location(), rods_amount)
 		transfer_fingerprints_to(R)
 
 /obj/structure/grille/proc/repair_grille()

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -3,7 +3,7 @@
 	greyscale_colors = null
 
 /obj/item/clothing/gloves/color/yellow
-	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
+	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -102,7 +102,7 @@
 	desc = "The old gloves your great grandfather stole from Engineering, many moons ago. They've seen some tough times recently."
 
 /obj/item/clothing/gloves/color/black
-	desc = "These gloves are fire-resistant."
+	desc = "These gloves are fire-resistant and grippy, enabling faster construction."
 	name = "black gloves"
 	icon_state = "black"
 	greyscale_colors = "#2f2e31"
@@ -112,6 +112,7 @@
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	resistance_flags = NONE
 	cut_type = /obj/item/clothing/gloves/fingerless
+	clothing_traits = list(TRAIT_QUICK_BUILD)
 
 /obj/item/clothing/gloves/fingerless
 	name = "fingerless gloves"

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -35,8 +35,10 @@
 /obj/item/clothing/head/utility/hardhat/proc/toggle_helmet_light(mob/living/user)
 	on = !on
 	if(on)
+		playsound(src, 'sound/weapons/magin.ogg', 40, TRUE, ignore_walls = FALSE)
 		turn_on(user)
 	else
+		playsound(src, 'sound/weapons/magout.ogg', 40, TRUE, ignore_walls = FALSE)
 		turn_off(user)
 	update_appearance()
 

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/mask/gas
 	name = "gas mask"
-	desc = "A face-covering mask that can be connected to an air supply. Good for concealing your identity and with a filter slot to help remove those toxins." //More accurate
+	desc = "A face-covering mask that can be connected to an air supply. Helps to protect your face against caustic environments."
 	icon_state = "gasmask_scoundrel"
 	clothing_flags = BLOCK_GAS_SMOKE_EFFECT | MASKINTERNALS | GAS_FILTERING
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -12,7 +12,7 @@
 	icon = 'icons/obj/ore.dmi'
 	icon_state = "ore"
 	inhand_icon_state = null
-	full_w_class = WEIGHT_CLASS_BULKY
+	full_w_class = WEIGHT_CLASS_NORMAL
 	singular_name = "ore chunk"
 	material_flags = MATERIAL_EFFECTS
 	var/points = 0 //How many points this ore gets you from the ore redemption machine

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -775,14 +775,14 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 
 	return ..()
 
-/obj/item/modular_computer/wrench_act(mob/living/user, obj/item/tool)
+/*/obj/item/modular_computer/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
 	tool.play_tool_sound(src, user, 20, volume=20)
 	new /obj/item/stack/sheet/iron(get_turf(loc), steel_sheet_cost)
 	user.balloon_alert(user, "disassembled")
 	relay_qdel()
 	qdel(src)
-	return TOOL_ACT_TOOLTYPE_SUCCESS
+	return TOOL_ACT_TOOLTYPE_SUCCESS*/
 
 /obj/item/modular_computer/welder_act(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -233,10 +233,8 @@
 
 /obj/item/pen/sleepy/Initialize(mapload)
 	. = ..()
-	create_reagents(45, OPENCONTAINER)
-	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 20)
-	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 15)
-	reagents.add_reagent(/datum/reagent/toxin/staminatoxin, 10)
+	create_reagents(10, OPENCONTAINER)
+	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 10)
 
 /*
  * (Alan) Edaggers

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -113,6 +113,7 @@
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
 	projectile_damage_multiplier = 15
+	weapon_weight = WEAPON_HEAVY // there's a bug with onehanded weapons using the automatic_fire component. when fixed, reduce this to medium or light
 
 /obj/item/gun/ballistic/automatic/wt550/Initialize(mapload)
 	. = ..()

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -109,6 +109,7 @@
 	knife_x_offset = 20
 	knife_y_offset = 12
 	projectile_damage_multiplier = 20
+	pickup_sound = null
 
 /obj/item/gun/energy/recharge/ebow/halloween
 	name = "candy corn crossbow"
@@ -129,3 +130,4 @@
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	projectile_damage_multiplier = 30
+	pickup_sound = 'sound/weapons/gun/pistol/slide_drop.ogg'

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -12,7 +12,7 @@
 /datum/uplink_item/device_tools/soap
 	name = "Syndicate Soap"
 	desc = "A sinister-looking surfactant used to clean blood stains to hide murders and prevent DNA analysis. \
-			You can also drop it underfoot to slip people."
+			You can also drop it underfoot to slip people -- it's extra slippery and it'll keep them down longer."
 	item = /obj/item/soap/syndie
 	cost = 5
 	surplus = 50

--- a/code/modules/uplink/uplink_items/job.dm
+++ b/code/modules/uplink/uplink_items/job.dm
@@ -168,7 +168,7 @@
 /datum/uplink_item/role_restricted/mimery
 	name = "Guide to Advanced Mimery Series"
 	desc = "The classical two part series on how to further hone your mime skills. Upon studying the series, the user should be able to make 3x1 invisible walls, and shoot bullets out of their fingers. \
-			Obviously only works for Mimes."
+			If the user is not already a mime, the use of these skills will require a vow of silence."
 	progression_minimum = 30 MINUTES
 	cost = 60
 	item = /obj/item/storage/box/syndie_kit/mimery

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -69,9 +69,8 @@
 
 /datum/uplink_item/stealthy_weapons/sleepy_pen
 	name = "Sleepy Pen"
-	desc = "A syringe disguised as a functional pen, filled with a potent mix of drugs, including a \
-			strong anesthetic and a chemical that prevents the target from speaking. \
-			The pen holds one dose of the mixture, and can be refilled with any chemicals. Note that before the target \
+	desc = "A syringe disguised as a functional pen, filled with 10 units of a potent anesthetic. \
+			The pen holds one dose, and can be refilled with any chemicals using a syringe. Note that before the target \
 			falls asleep, they will be able to move and act."
 	item = /obj/item/pen/sleepy
 	cost = 25

--- a/scoundrel/code/game/objects/items/storage/medkit.dm
+++ b/scoundrel/code/game/objects/items/storage/medkit.dm
@@ -58,6 +58,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 8
 	throwforce = 8
+/obj/item/storage/medkit/emergency/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/medkit/emergency/PopulateContents()
 	if(empty)
@@ -158,6 +161,9 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 10
 	throwforce = 10
+/obj/item/storage/medkit/ancient/Initialize(mapload)
+	. = ..()
+	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 
 /obj/item/storage/medkit/ancient/PopulateContents()
 	if(empty)
@@ -297,7 +303,6 @@
 	icon_state = "medkit_tactical"
 	inhand_icon_state = "medkit-tactical"
 	damagetype_healed = "all"
-	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/medkit/tactical/Initialize(mapload)
 	. = ..()

--- a/scoundrel/code/modules/cargo/packs/engineering_tools.dm
+++ b/scoundrel/code/modules/cargo/packs/engineering_tools.dm
@@ -24,7 +24,7 @@
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engineering/rcd
+/datum/supply_pack/tools/rcd
 	name = "Rapid Construction Device (RCD) Crate"
 	desc = "Rapid Construction Devices for rapidly constructing...things. And also deconstructiong them, but don't tell anyone!"
 	cost = CARGO_CRATE_VALUE * 16
@@ -33,7 +33,7 @@
 	crate_name = "rapid construction device crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engineering/rpd
+/datum/supply_pack/tools/rpd
 	name = "Rapid Pipe Dispenser (RPD) Crate"
 	desc = "For quickly and effecitvely laying pipes for all your gas transference needs!"
 	cost = CARGO_CRATE_VALUE * 5
@@ -42,7 +42,7 @@
 	crate_name = "rapid pipe dispenser crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engineering/plumbing_constructor
+/datum/supply_pack/tools/plumbing_constructor
 	name = "Plumbing Constructor Crate"
 	desc = "For quickly and effecitvely putting down ugly plastic tubes for use in biochemical experiments and admixtures!"
 	cost = CARGO_CRATE_VALUE * 7


### PR DESCRIPTION
## About The Pull Request
more misc stuff
## Why It's Good For The Game
## Changelog
:cl:
add: syndicate boxes can be crafted from cardboard
add: hardhat light sounds
balance: WT requires two hands to wield
balance: ancient medkits cannot store normal items
balance: black gloves offer a construction speed bonus
balance: sleepy pen can now only hold 10 chems, and has had its starting chems nerfed
balance: basic soaps have have their slips halved
balance: picking up an ebow is now silent
balance: gauze is now applied faster
fix: candle packs cannot store normal items
fix: advanced mimery uplink entry flavor text
fix: ore stacking size issue patched
fix: some cargo crate categories
fix: fixed grilles sometims not returning rods when broken
fix: removed PDA deconstruction because it only existed to cause problems
fix: gasmask description no longer mentions filters
fix: insuls description no longer references chunky fingers
fix: chairs can now be caught when thrown
/:cl:
