### PR TITLE
Access inscribers

### DIFF
--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -185,8 +185,8 @@
 	var/aux_hijack_time = 8 SECONDS
 	var/recharge_time = 60 SECONDS
 
-	// whether the inscriber checks for a closed/secure panel
-	var/skip_panel = FALSE
+	// the security level of an airlock that the inscriber is willing to ignore. greater than 1 will also bypass the screwdriver panel
+	var/security_override = 0
 
 /obj/item/card/access_inscriber/Initialize(mapload)
 	. = ..()
@@ -212,10 +212,13 @@
 			to_chat(user, span_warning("[src] buzzes quietly. It needs to recharge!"))
 			return
 
-		else if(skip_panel == FALSE)
-			if(airlock.panel_open == FALSE || airlock.security_level > 0)
-				to_chat(user, span_warning("You need access to the electronics!"))
-				return
+		else if(airlock.security_level > security_override)
+			to_chat(user, span_warning("You need access to the electronics!"))
+			return
+		
+		if(airlock.panel_open == FALSE && airlock.security_level >= security_override)
+			to_chat(user, span_warning("You need access to the electronics!"))
+			return
 
 		if(hijack_time)
 			do_sparks(1, TRUE, src)
@@ -248,7 +251,7 @@
 			to_chat(user, span_warning("[src] buzzes quietly. It needs to recharge!"))
 			return
 
-		else if(skip_panel == FALSE)
+		else if(security_override < 1)
 			if(apc.panel_open == FALSE)
 				to_chat(user, span_warning("You need access to the electronics!"))
 				return
@@ -269,7 +272,7 @@
 			to_chat(user, span_warning("[src] buzzes quietly. It needs to recharge!"))
 			return
 
-		else if(skip_panel == FALSE)
+		else if(security_override < 1)
 			if(alarm.panel_open == FALSE)
 				to_chat(user, span_warning("You need access to the electronics!"))
 				return
@@ -309,7 +312,7 @@
 	hijack_time = null
 	locker_hijack_time = 8 SECONDS
 	aux_hijack_time = null
-	skip_panel = TRUE
+	security_override = 5 // just short of getting through plasteel plating
 	access_string = "The programming chip is black and suspiciously unmarked."
 
 /obj/item/card/access_inscriber/default

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -217,11 +217,11 @@
 				to_chat(user, span_warning("You need access to the electronics!"))
 				return
 
-		else if(hijack_time)
+		if(hijack_time)
+			do_sparks(1, TRUE, src)
+			to_chat(user, span_warning("You begin reprogramming the electronics!"))
 			if(do_after(user, hijack_time))
 				hijack_access(airlock, user)
-				do_sparks(1, TRUE, src)
-				to_chat(user, span_warning("You begin reprogramming the electronics!"))
 		else
 			hijack_access(airlock, user)
 
@@ -233,10 +233,10 @@
 			to_chat(user, span_warning("[src] buzzes quietly. It needs to recharge!"))
 			return
 		else if(locker_hijack_time)
+			to_chat(user, span_warning("You begin reprogramming the electronics!"))
+			do_sparks(1, TRUE, src)
 			if(do_after(user, locker_hijack_time))
 				hijack_access(locker, user)
-				do_sparks(1, TRUE, src)
-				to_chat(user, span_warning("You begin reprogramming the electronics!"))
 		else
 			hijack_access(locker, user)
 
@@ -254,10 +254,10 @@
 				return
 
 		if(aux_hijack_time)
+			to_chat(user, span_warning("You begin reprogramming the electronics!"))
+			do_sparks(1, TRUE, src)
 			if(do_after(user, aux_hijack_time))
 				hijack_access(apc, user)
-				do_sparks(1, TRUE, src)
-				to_chat(user, span_warning("You begin reprogramming the electronics!"))
 		else
 			hijack_access(apc, user)
 
@@ -275,10 +275,10 @@
 				return
 
 		if(aux_hijack_time)
+			to_chat(user, span_warning("You begin reprogramming the electronics!"))
+			do_sparks(1, TRUE, src)
 			if(do_after(user, aux_hijack_time))
 				hijack_access(alarm, user)
-				do_sparks(1, TRUE, src)
-				to_chat(user, span_warning("You begin reprogramming the electronics!"))
 		else
 			hijack_access(alarm, user)
 
@@ -312,17 +312,23 @@
 	skip_panel = TRUE
 	access_string = "The programming chip is black and suspiciously unmarked."
 
+/obj/item/card/access_inscriber/default
+	name = "default access inscriber"
+	inscribed_access = null
+	inscribed_one_access = null
+	access_string = "It's programmed to reset access to defaults."
+
 /obj/item/card/access_inscriber/maintenance
 	name = "maintenance access inscriber"
 	inscribed_access = null
 	inscribed_one_access = list(ACCESS_MAINT_TUNNELS)
-	access_string = "It's programmed to set MAINTENANCE access requirements."
+	access_string = "It's programmed to add MAINTENANCE access requirements."
 
 /obj/item/card/access_inscriber/command
 	name = "command access inscriber"
 	inscribed_access = null
 	inscribed_one_access = list(ACCESS_COMMAND)
-	access_string = "It's programmed to set COMMAND access requirements."
+	access_string = "It's programmed to add COMMAND access requirements."
 
 // choice inscriber
 /obj/item/card/access_inscriber/choice
@@ -331,7 +337,6 @@
 	inscribed_one_access = null
 	access_string = "It's programmed to reset access to defaults."
 	var/selection = 0
-	max_charges = 6
 
 //i'm sure this could be done much better, i just don't know how
 /obj/item/card/access_inscriber/choice/attack_self(mob/user, modifiers)

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -160,7 +160,7 @@
 
 // scoundrel content
 /obj/item/card/access_inscriber
-	name = "default access inscriber"
+	name = "access inscriber"
 	desc = "A tool used to quickly inscribe access to airlocks and machinery."
 	icon_state = "doorjack"
 	worn_icon_state = "doorjack"
@@ -327,7 +327,6 @@
 
 // choice inscriber
 /obj/item/card/access_inscriber/choice
-	name = "access inscriber"
 	desc = "A tool used to quickly inscribe access to airlocks and machinery. This one can be activated to choose from a selection of access types."
 	inscribed_access = null
 	inscribed_one_access = null

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -180,10 +180,10 @@
 
 	// how long it takes to hijack access. null skips the do_after and makes it instant
 	var/hijack_time = 16 SECONDS
-	var/locker_hijack_time = 30 SECONDS // can't make it that easy
+	var/locker_hijack_time = 60 SECONDS // discourage bad behavior
 	// used for APCs and air alarms
 	var/aux_hijack_time = 8 SECONDS
-	var/recharge_time = 30 SECONDS
+	var/recharge_time = 60 SECONDS
 
 	// whether the inscriber checks for a closed/secure panel
 	var/skip_panel = FALSE
@@ -310,7 +310,6 @@
 	locker_hijack_time = 8 SECONDS
 	aux_hijack_time = null
 	skip_panel = TRUE
-	recharge_time = 60 SECONDS
 	access_string = "The programming chip is black and suspiciously unmarked."
 
 /obj/item/card/access_inscriber/maintenance

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -183,7 +183,7 @@
 	var/locker_hijack_time = 60 SECONDS // discourage bad behavior
 	// used for APCs and air alarms
 	var/aux_hijack_time = 8 SECONDS
-	var/recharge_time = 120 SECONDS
+	var/recharge_time = 90 SECONDS
 
 	// the security level of an airlock that the inscriber is willing to ignore. greater than 1 will also bypass the screwdriver panel
 	var/security_override = 0

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -287,6 +287,9 @@
 
 /obj/item/card/access_inscriber/proc/hijack_access(atom/target, mob/user)
 	var/obj/O = target
+	if(charges < 1)
+		to_chat(user, span_warning("[src] buzzes quietly. It needs to recharge!"))
+		return
 	if(O.req_access == inscribed_access && O.req_one_access == inscribed_one_access)
 		to_chat(user, span_warning("[src] buzzes quietly! The access is already matching."))
 		return

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -180,7 +180,7 @@
 
 	// how long it takes to hijack access. null skips the do_after and makes it instant
 	var/hijack_time = 16 SECONDS
-	var/locker_hijack_time = 60 SECONDS // discourage bad behavior
+	var/locker_hijack_time = 45 SECONDS // discourage bad behavior
 	// used for APCs and air alarms
 	var/aux_hijack_time = 8 SECONDS
 	var/recharge_time = 90 SECONDS

--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -183,7 +183,7 @@
 	var/locker_hijack_time = 60 SECONDS // discourage bad behavior
 	// used for APCs and air alarms
 	var/aux_hijack_time = 8 SECONDS
-	var/recharge_time = 60 SECONDS
+	var/recharge_time = 120 SECONDS
 
 	// the security level of an airlock that the inscriber is willing to ignore. greater than 1 will also bypass the screwdriver panel
 	var/security_override = 0

--- a/code/game/objects/structures/crates_lockers/closets/scoundrel_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/scoundrel_closets.dm
@@ -35,6 +35,7 @@
 	..()
 
 	new /obj/item/storage/backpack/duffelbag(src)
+	new /obj/item/card/access_inscriber/choice(src)
 	new /obj/item/computer_disk/command/ce(src)
 	new /obj/item/radio/headset/(src)
 	new /obj/item/holosign_creator/atmos(src)
@@ -61,6 +62,7 @@
 	..()
 
 	new /obj/item/storage/backpack/duffelbag(src)
+	new /obj/item/card/access_inscriber/choice(src)
 	new /obj/item/computer_disk/command/captain(src)
 	new /obj/item/storage/box/silver_ids(src)
 	new /obj/item/radio/headset/heads/captain/alt(src)
@@ -78,6 +80,7 @@
 /obj/structure/closet/secure_closet/quartermaster_scoundrel/PopulateContents()
 	..()
 	new /obj/item/storage/backpack/duffelbag(src)
+	new /obj/item/card/access_inscriber/choice(src)
 	new /obj/item/radio/headset/heads/captain/alt(src)
 	new /obj/item/universal_scanner(src)
 	new /obj/item/door_remote/captain(src)

--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -150,7 +150,7 @@
 	name = "Shadow Kit"
 	desc = "A ready-assembled loadout for stalking the shadows. Comes loaded with: \
 	A book on shadow-walking, granting the ability to disappear into darkness and recover health, a smoke spellbook, \
-	a pair of nightvision goggles, and a box of reinforced bolas. \
+	a pair of nightvision goggles, a box of reinforced bolas, and a Syndicate access inscriber. \
 	Not recommended for beginners."
 	item = /obj/item/storage/toolbox/loadout/shadow
 
@@ -158,7 +158,7 @@
 	name = "Night Surgeon Kit"
 	desc = "A ready-assembled loadout suited to kidnapping and medical crimes. Comes loaded with: \
 	A Syndicate surgery bag, a Syndicate shelter capsule, a dart pistol, a poison kit, a brainwashing surgery disk, a sleepy pen, and \
-	a radioactive microlaser. \
+	a Syndicate access inscriber. \
 	Not recommended for beginners."
 	item = /obj/item/storage/toolbox/loadout/surgeon
 

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -80,8 +80,8 @@
 	restricted access. Can be used on its own to lock non-Agents out of airlocks, lockers, APCs and air alarms, but an agent card \
 	can be used in conjunction to allow for exclusive access."
 	item = /obj/item/card/access_inscriber/syndicate
-	cost = 15
-	limited_stock = 2
+	cost = 20
+	limited_stock = 1
 
 /datum/uplink_item/device_tools/fakenucleardisk
 	name = "Decoy Nuclear Authentication Disk"

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -74,12 +74,14 @@
 	item = /obj/item/storage/belt/military
 	cost = 1*/
 
-/datum/uplink_item/device_tools/doorjack
-	name = "Doorjack"
-	desc = "A specialized cryptographic sequencer specifically designed to override station airlock access codes. \
-			After hacking a certain number of airlocks, the device will require some time to recharge."
-	item = /obj/item/card/emag/doorjack
+/datum/uplink_item/device_tools/access_inscriber
+	name = "Syndicate Access Inscriber"
+	desc = "A specialized access-inscription device capable of instantly overriding access requirements with Syndicate-only \
+	restricted access. Can be used on its own to lock non-Agents out of airlocks, lockers, APCs and air alarms, but an agent card \
+	can be used in conjunction to allow for exclusive access."
+	item = /obj/item/card/access_inscriber/syndicate
 	cost = 10
+	limited_stock = 2
 
 /datum/uplink_item/device_tools/fakenucleardisk
 	name = "Decoy Nuclear Authentication Disk"

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -80,7 +80,7 @@
 	restricted access. Can be used on its own to lock non-Agents out of airlocks, lockers, APCs and air alarms, but an agent card \
 	can be used in conjunction to allow for exclusive access."
 	item = /obj/item/card/access_inscriber/syndicate
-	cost = 10
+	cost = 15
 	limited_stock = 2
 
 /datum/uplink_item/device_tools/fakenucleardisk

--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -511,6 +511,7 @@
 	new /obj/item/book/granter/action/spell/smoke/robeless/shadowkit(src)
 	new /obj/item/clothing/glasses/night(src)
 	new /obj/item/storage/box/r_bolas(src)
+	new /obj/item/card/access_inscriber/syndicate(src)
 //	new /obj/item/implanter/ventcrawling/deluxe(src) // add this back in when the exploits are fixed
 
 // surgeon kit
@@ -521,7 +522,7 @@
 	new /obj/item/storage/box/syndie_kit/chemical(src)
 	new /obj/item/disk/surgery/brainwashing(src)
 	new /obj/item/pen/sleepy(src)
-	new /obj/item/healthanalyzer/rad_laser(src)
+	new /obj/item/card/access_inscriber/syndicate(src)
 	new /obj/item/paper/fluff/poison_kit_guide(src)
 
 // mini toolboxes

--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -198,6 +198,7 @@
 
 /obj/item/storage/pouch/holding/leadership/PopulateContents()
 	new /obj/item/card/id/advanced/silver/leader_spare(src)
+	new /obj/item/card/access_inscriber/choice(src)
 	new /obj/item/clothing/neck/stethoscope(src)
 	new /obj/item/door_remote/captain(src)
 	new /obj/item/paper/fluff/leadership_assignment(src)

--- a/scoundrel/code/modules/mapfluff/alibi.dm
+++ b/scoundrel/code/modules/mapfluff/alibi.dm
@@ -71,5 +71,8 @@
 	make the right call with it. No one having bridge access in an emergency can be as dangerous as \
 	letting it fall into the wrong hands. <br><br> \
 	\
-	Additionally, you've been provided a command remote and a stethoscope to extract the master keycard \
-	from the vault's safe, if necessary."
+	You've been provided a command remote and a stethoscope to extract the master keycard \
+	from the vault's safe, if necessary. <br><br> \
+	\
+	Additionally, a spare access inscriber has been included to repair or modify restrictions on \
+	airlocks and devices."


### PR DESCRIPTION

## About The Pull Request
Adds access inscribers, capable of overriding door accesses without the use of an RCD.
Also adds a syndicate version that operates much faster than the standard.
The engineering specialist, captain and quartermaster get access inscribers that can cycle modes. The acting captain is provided an extra inscriber in the relevant pouch.
## Why It's Good For The Game
## Changelog
:cl:
add: added access inscribers
add: added syndicate access inscriber to the uplink
balance: night surgeon & shadow kit have been provided syndicate access inscribers
/:cl:
