### PR TITLE
Pouch buff

### DIFF
--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -16,8 +16,8 @@
 /obj/item/storage/pouch/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	atom_storage.max_slots = 3
-	atom_storage.max_total_storage = 4
+	atom_storage.max_slots = 4
+	atom_storage.max_total_storage = 5
 	atom_storage.rustle_sound = FALSE
 
 //cuffs
@@ -212,7 +212,7 @@
 /obj/item/storage/pouch/traitor/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	atom_storage.max_slots = 6
+	atom_storage.max_slots = 8
 	atom_storage.max_total_storage = 8
 	atom_storage.silent = TRUE
 

--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -16,7 +16,7 @@
 /obj/item/storage/pouch/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	atom_storage.max_slots = 4
+	atom_storage.max_slots = 5
 	atom_storage.max_total_storage = 5
 	atom_storage.rustle_sound = FALSE
 

--- a/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
+++ b/scoundrel/code/game/objects/items/storage/new_storage_scoundrel.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 3
-	atom_storage.max_total_storage = 3
+	atom_storage.max_total_storage = 4
 	atom_storage.rustle_sound = FALSE
 
 //cuffs
@@ -213,7 +213,7 @@
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 6
-	atom_storage.max_total_storage = 6
+	atom_storage.max_total_storage = 8
 	atom_storage.silent = TRUE
 
 /obj/item/storage/pouch/traitor/nanotrasen


### PR DESCRIPTION
## About The Pull Request
Slight buff to generalist pouches
## Why It's Good For The Game
Pouches atm are very irrelevant content between nested inventories being a pain to use and being unable to store very many items that actually matter in them. I think it's an improvement for the game's dynamic as well, to have some means of squeezing a little more stuff into your inventory if you're desperate.
## Changelog
:cl:
balance: pouch max storage 3 > 5
balance : traitor pouch max storage 6 > 8
/:cl:
