### PR TITLE
Railing projectile pass fix

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -81,8 +81,9 @@
 
 /obj/structure/railing/CanPass(atom/movable/mover, border_dir)
 	. = ..()
+	var/mob/living/carbon/C = mover
 	if(border_dir & dir)
-		return . || mover.throwing //|| mover.movement_type & (FLYING | FLOATING)
+		return . || mover.throwing || isprojectile(mover) || C.body_position != STANDING_UP //|| mover.movement_type & (FLYING | FLOATING)
 	return TRUE
 
 /obj/structure/railing/CanAStarPass(obj/item/card/id/ID, to_dir, atom/movable/caller, no_id = FALSE)
@@ -109,6 +110,13 @@
 		return
 
 	if (leaving.move_force >= MOVE_FORCE_EXTREMELY_STRONG)
+		return
+	
+	if (isprojectile(leaving))
+		return
+	
+	var/mob/living/carbon/C = leaving
+	if (C.body_position != STANDING_UP)
 		return
 
 	leaving.Bump(src)


### PR DESCRIPTION

## About The Pull Request
Railings were blocking projectiles, so this fixes that.
Also! If the player is horizontal, they can pass railings, to simulate crawling under them.
## Why It's Good For The Game
railings were exploitable in some severe ways. this also adds room for skill expression in a small, meaningful way
## Changelog
:cl:
balance: crawling now lets you pass through railings
fix: railings no longer block projectiles
/:cl:
