### PR TITLE
Traitor objective rework and reflavoring + Scoundrel midrounds

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -19,6 +19,7 @@
 #define ROLE_WIZARD "Wizard"
 
 // Midround roles
+#define ROLE_MIDROUND_SCOUNDREL "Troublemaker"
 #define ROLE_ABDUCTOR "Abductor"
 #define ROLE_ALIEN "Xenomorph"
 #define ROLE_BLOB "Blob"

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -841,3 +841,52 @@
 	message_admins("[ADMIN_LOOKUPFLW(obsessed)] has been made Obsessed by the midround ruleset.")
 	log_game("[key_name(obsessed)] was made Obsessed by the midround ruleset.")
 	return TRUE
+
+//////////////////////////////////////////////
+//                                          //
+//               SCOUNDREL                  //
+//                                          //
+//////////////////////////////////////////////
+
+/datum/dynamic_ruleset/midround/from_living/autoscoundrel
+	name = "Troublemaker"
+	midround_ruleset_style = MIDROUND_RULESET_STYLE_LIGHT
+	antag_datum = /datum/antagonist/scoundrel
+	antag_flag = ROLE_MIDROUND_SCOUNDREL
+	antag_flag_override = ROLE_SCOUNDREL
+	protected_roles = list(
+		JOB_CAPTAIN_SCOUNDREL,
+		JOB_DETECTIVE_SCOUNDREL,
+		JOB_QUARTERMASTER_SCOUNDREL,
+	)
+	restricted_roles = list(
+		JOB_AI,
+		JOB_CYBORG,
+		ROLE_POSITRONIC_BRAIN,
+	)
+	required_candidates = 1
+	weight = 10
+	cost = 6
+	requirements = list(8,8,8,8,8,8,8,8,8,8)
+	repeatable = TRUE
+
+/datum/dynamic_ruleset/midround/from_living/autoscoundrel/trim_candidates()
+	..()
+	candidates = living_players
+	for(var/mob/living/player in candidates)
+		if(issilicon(player)) // Your assigned role doesn't change when you are turned into a silicon.
+			candidates -= player
+		else if(is_centcom_level(player.z))
+			candidates -= player // We don't autotator people in CentCom
+		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
+			candidates -= player // We don't autotator people with roles already
+
+/datum/dynamic_ruleset/midround/from_living/autoscoundrel/execute()
+	var/mob/M = pick(candidates)
+	assigned += M
+	candidates -= M
+	var/datum/antagonist/scoundrel/newScoundrel = new
+	M.mind.add_antag_datum(newScoundrel)
+	message_admins("[ADMIN_LOOKUPFLW(M)] was selected by the [name] ruleset and has been made into a midround scoundrel.")
+	log_dynamic("[key_name(M)] was selected by the [name] ruleset and has been made into a midround scoundrel.")
+	return TRUE

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -212,12 +212,12 @@ and any other temporary traits. - Jan 2023
 
 /obj/item/implanter/killswitch
 	name = "implanter (killswitch)"
-	desc = "When activated, who knows what will happen!"
+	desc = "Who knows what'll happen if it's activated?"
 	imp_type = /obj/item/implant/killswitch
 
 /obj/item/implant/killswitch
 	name = "killswitch implant"
-	desc = "Why is it beeping like that?."
+	desc = "Why is it beeping like that?"
 	actions_types = null
 	icon_state = "adrenal"
 

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -207,3 +207,51 @@ and any other temporary traits. - Jan 2023
 /obj/item/implanter/ventcrawling/deluxe
 	name = "implanter (bluespace contortion)"
 	imp_type = /obj/item/implant/ventcrawling/deluxe
+
+// The Killswitch Implant
+
+/obj/item/implanter/killswitch
+	name = "implanter (killswitch)"
+	desc = "When activated, who knows what will happen!"
+	imp_type = /obj/item/implant/killswitch
+
+/obj/item/implant/killswitch
+	name = "killswitch implant"
+	desc = "Why is it beeping like that?."
+	actions_types = null
+	icon_state = "adrenal"
+
+/obj/item/implant/killswitch/implant(mob/living/target, mob/user, silent = FALSE, force = FALSE)
+	. = ..()
+	if(!.)
+		return FALSE
+	ADD_TRAIT(target, TRAIT_GAMER, IMPLANT_TRAIT)
+	return TRUE
+
+/obj/item/implant/killswitch/removed(mob/target, silent = FALSE, special = FALSE)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(isliving(target))
+		var/mob/living/L = target
+		REMOVE_TRAIT(L, TRAIT_GAMER, IMPLANT_TRAIT)
+	return TRUE
+
+/obj/item/implantcase/killswitch
+	name = "implant case - 'Killswitch'"
+	desc = "A glass case containing a killswitch implant."
+	imp_type = /obj/item/implant/killswitch
+
+/obj/item/storage/box/killimp
+	name = "boxed killswitch implant kit"
+	desc = "Box of stuff used to implant killswitches."
+	icon_state = "syndiebox"
+	illustration = "implant"
+
+/obj/item/storage/box/chemimp/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/implantcase/killswitch = 5,
+		/obj/item/implanter = 1,
+		/obj/item/implantpad = 1,
+	)
+	generate_items_inside(items_inside,src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -598,6 +598,13 @@
 		group.register(i)
 	desc += " The implants are registered to the \"[group.name]\" group."
 
+// scoundrel content
+// killswitch implants, used by the mass killswitch implanting objective
+/obj/item/storage/box/syndie_kit/killswitches/PopulateContents()
+	. = ..()
+	for(var/i in 1 to 7)
+		new /obj/item/implanter/killswitch(src)
+
 #undef KIT_RECON
 #undef KIT_BLOODY_SPAI
 #undef KIT_STEALTHY

--- a/code/modules/antagonists/scoundrel/scoundrel.dm
+++ b/code/modules/antagonists/scoundrel/scoundrel.dm
@@ -35,16 +35,20 @@
     equal parts."))
 
 /datum/antagonist/scoundrel/proc/create_objectives()
+	var/datum/objective/beatdown_objective
+	var/datum/objective/loyalty_objective
 	if(prob(75))
-		var/datum/objective/scoundrel_beatdown/beatdown_objective = new
+		beatdown_objective = new /datum/objective/scoundrel_beatdown
 		beatdown_objective.owner = owner
 		beatdown_objective.find_target()
 		beatdown_objective.completed = TRUE
 		objectives += beatdown_objective
 	if(prob(75))
-		var/datum/objective/scoundrel_loyalty/loyalty_objective = new
+		loyalty_objective = new /datum/objective/scoundrel_loyalty
 		loyalty_objective.owner = owner
 		loyalty_objective.find_target()
+		if(loyalty_objective.target == beatdown_objective.target)
+			loyalty_objective.target = null
 		loyalty_objective.completed = TRUE
 		objectives += loyalty_objective
 
@@ -64,7 +68,7 @@
 
 	// if no objectives roll, just roll beatdown
 	if(!objectives)
-		var/datum/objective/scoundrel_beatdown/beatdown_objective = new
+		beatdown_objective = new /datum/objective/scoundrel_beatdown
 		beatdown_objective.owner = owner
 		beatdown_objective.find_target()
 		beatdown_objective.completed = TRUE

--- a/code/modules/antagonists/scoundrel/scoundrel.dm
+++ b/code/modules/antagonists/scoundrel/scoundrel.dm
@@ -47,8 +47,13 @@
 		loyalty_objective = new /datum/objective/scoundrel_loyalty
 		loyalty_objective.owner = owner
 		loyalty_objective.find_target()
-		if(loyalty_objective.target == beatdown_objective.target)
-			loyalty_objective.target = null
+		// if you get the same target for beatdown and loyalty, restarting the instance without a target
+		if(beatdown_objective) // because it will crash if beatdown is null
+			if(loyalty_objective.target == beatdown_objective.target && loyalty_objective.target != null)
+				qdel(loyalty_objective)
+				loyalty_objective = new /datum/objective/scoundrel_loyalty
+				loyalty_objective.owner = owner
+				loyalty_objective.update_explanation_text()
 		loyalty_objective.completed = TRUE
 		objectives += loyalty_objective
 

--- a/code/modules/antagonists/scoundrel/scoundrel.dm
+++ b/code/modules/antagonists/scoundrel/scoundrel.dm
@@ -62,6 +62,7 @@
 		var/datum/objective/steal/steal_objective = new
 		steal_objective.owner = owner
 		steal_objective.find_target()
+		steal_objective.completed = TRUE
 		objectives += steal_objective
 
 	if(prob(75))

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -391,6 +391,8 @@ GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
 		/datum/objective/killswitch_mass,
 		/datum/objective/killswitch_target,
 		/datum/objective/murdermess,
+		/datum/objective/mutiny,
+		/datum/objective/dangerous_experiment,
 	))
 /datum/objective/recruitment_drive
 	name = "recruitment drive"
@@ -438,6 +440,9 @@ GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
 	explanation_text = "Implant as many crewmembers with the killswitch implant as possible."
 	martyr_compatible = TRUE
 	admin_grantable = TRUE
+/datum/objective/killswitch_mass/update_explanation_text()
+	. = ..()
+	give_special_equipment(list(/obj/item/storage/box/syndie_kit/killswitches))
 
 /datum/objective/killswitch_target
 	name = "targeted killswitch implanting"
@@ -445,6 +450,9 @@ GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
 	by any means necessary."
 	martyr_compatible = TRUE
 	admin_grantable = TRUE
+/datum/objective/killswitch_target/update_explanation_text()
+	. = ..()
+	give_special_equipment(list(/obj/item/implanter/killswitch))
 
 /datum/objective/murdermess
 	name = "make a mess"
@@ -455,3 +463,15 @@ GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
 	. = ..()
 	if(target)
 		explanation_text = "They aren't getting the message. Make a huge fucking mess out of [target.name]'s corpse and make sure everyone sees it."
+
+/datum/objective/mutiny
+	name = "mutiny"
+	explanation_text = "Rile the crew against the acting leadership and take charge by any means necessary."
+	martyr_compatible = TRUE
+	admin_grantable = TRUE
+
+/datum/objective/dangerous_experiment
+	name = "dangerous experiment"
+	explanation_text = "Use the station as a testing ground for dangerous experiments."
+	martyr_compatible = TRUE
+	admin_grantable = TRUE

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -376,12 +376,9 @@
 /datum/outfit/traitor
 	name = "Traitor (Preview only)"
 
-	uniform = /obj/item/clothing/under/color/grey
-	suit = /obj/item/clothing/suit/hooded/ablative
-	gloves = /obj/item/clothing/gloves/color/yellow
+	suit = /obj/item/clothing/under/starsuit/executive
 	mask = /obj/item/clothing/mask/gas
-	l_hand = /obj/item/melee/energy/sword
-	r_hand = /obj/item/gun/energy/recharge/ebow
+	l_hand = /obj/item/gun/energy/recharge/ebow
 
 /datum/outfit/traitor/post_equip(mob/living/carbon/human/H, visualsOnly)
 	var/obj/item/melee/energy/sword/sword = locate() in H.held_items

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -211,7 +211,15 @@
 	objective_completion.owner = owner
 	objectives += objective_completion */
 
-	var/datum/objective/main_objective = pick(GLOB.syndicate_agent_objectives)
+	var/datum/objective/antag_disposition/disposition_objective = new /datum/objective/antag_disposition
+	if(disposition_objective)
+		disposition_objective.owner = owner
+		disposition_objective.update_explanation_text()
+		disposition_objective.completed = TRUE
+		objectives += disposition_objective
+
+	var/picked_objective = pick(GLOB.syndicate_agent_objectives)
+	var/datum/objective/main_objective = new picked_objective
 	if(main_objective)
 		main_objective.owner = owner
 		main_objective.find_target()
@@ -365,6 +373,15 @@
 		H.update_held_items()
 */
 
+/datum/objective/antag_disposition
+	name = "disposition"
+	explanation_text = "To the extent that does not interfere with your plans or objectives, treat the crew with a neutral disposition."
+	martyr_compatible = TRUE
+/datum/objective/antag_disposition/update_explanation_text()
+	. = ..()
+	var/disposition = pick(list("friendly", "neutral", "hostile"))
+	explanation_text = "To the extent that does not interfere with your plans or objectives, treat the crew with a [disposition] disposition."
+
 GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
 		/datum/objective/recruitment_drive,
 		/datum/objective/limb_repo,
@@ -373,43 +390,68 @@ GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
 		/datum/objective/hostile_environment,
 		/datum/objective/killswitch_mass,
 		/datum/objective/killswitch_target,
+		/datum/objective/murdermess,
 	))
 /datum/objective/recruitment_drive
 	name = "recruitment drive"
 	explanation_text = "Recruit as many people to the Syndicate's cause as possible, by any means necessary."
 	martyr_compatible = TRUE
+	admin_grantable = TRUE
 
 /datum/objective/limb_repo
 	name = "limb repossession"
 	explanation_text = "Dismember, collect and repossess two arms from the station crew."
 	martyr_compatible = TRUE
-/datum/objective/limb_repo/New(text)
-	. = ..()	
+	admin_grantable = TRUE
+/datum/objective/limb_repo/update_explanation_text()
+	. = ..()
 	var/number = pick(list(2, 3, 4))
 	var/limbs = pick(list("arms", "legs"))
-	text = "Dismember, collect and reposses [number] [limbs] from [target.name]."
+	if(target)
+		explanation_text = "Dismember, collect and reposses [number] [limbs] from [target.name]."
 
 /datum/objective/organ_repo
 	name = "organ repossession"
 	explanation_text = "Disembowel, collect and repossess a liver from the station crew."
 	martyr_compatible = TRUE
+	admin_grantable = TRUE
+/datum/objective/organ_repo/update_explanation_text()
+	. = ..()
+	var/organ = pick(list("liver", "set of lungs","stomach", "heart"))
+	if(target)
+		explanation_text = "Disembowel, collect and repossess a [organ] from [target.name]."
 
 /datum/objective/fundraiser
 	name = "fundraiser"
 	explanation_text = "Collect as many credits from the station as you can, by any means necessary."
 	martyr_compatible = TRUE
+	admin_grantable = TRUE
 
 /datum/objective/hostile_environment
 	name = "hostile environment"
 	explanation_text = "Make the station utterly uninhabitable for human life."
 	martyr_compatible = TRUE
+	admin_grantable = TRUE
 
 /datum/objective/killswitch_mass
 	name = "mass killswitch implanting"
 	explanation_text = "Implant as many crewmembers with the killswitch implant as possible."
 	martyr_compatible = TRUE
+	admin_grantable = TRUE
 
 /datum/objective/killswitch_target
 	name = "targeted killswitch implanting"
-	explanation_text = "Implant someone with the killswitch implant and ensure they escape with it alive."
+	explanation_text = "Implant someone with the killswitch implant and ensure they escape with it alive \
+	by any means necessary."
 	martyr_compatible = TRUE
+	admin_grantable = TRUE
+
+/datum/objective/murdermess
+	name = "make a mess"
+	explanation_text = "They aren't getting the message. Make a huge fucking mess out of someone's corpse and make sure everyone sees it."
+	martyr_compatible = TRUE
+	admin_grantable = TRUE
+/datum/objective/murdermess/update_explanation_text()
+	. = ..()
+	if(target)
+		explanation_text = "They aren't getting the message. Make a huge fucking mess out of [target.name]'s corpse and make sure everyone sees it."

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -211,39 +211,12 @@
 	objective_completion.owner = owner
 	objectives += objective_completion */
 
-	switch(rand(1,100))
-		if(1 to 32)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			kill_objective.find_target()
-			objectives += kill_objective
-
-			var/datum/objective/assassinate/kill_objective_2 = new
-			kill_objective_2.owner = owner
-			kill_objective_2.find_target()
-			objectives += kill_objective_2
-
-		if(33 to 65)
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = owner
-			steal_objective.find_target()
-			objectives += steal_objective
-
-			var/datum/objective/steal/steal_objective_2 = new
-			steal_objective_2.owner = owner
-			steal_objective_2.find_target()
-			objectives += steal_objective_2
-
-		if(66 to 100)
-			var/datum/objective/assassinate/kill_objective = new
-			kill_objective.owner = owner
-			kill_objective.find_target()
-			objectives += kill_objective
-
-			var/datum/objective/steal/steal_objective = new
-			steal_objective.owner = owner
-			steal_objective.find_target()
-			objectives += steal_objective
+	var/datum/objective/main_objective = pick(GLOB.syndicate_agent_objectives)
+	if(main_objective)
+		main_objective.owner = owner
+		main_objective.find_target()
+		main_objective.completed = TRUE
+		objectives += main_objective
 
 	var/datum/objective/objective_escape
 	var/random_escape = pick_weight(list(
@@ -379,7 +352,7 @@
 	suit = /obj/item/clothing/under/starsuit/executive
 	mask = /obj/item/clothing/mask/gas
 	l_hand = /obj/item/gun/energy/recharge/ebow
-
+/*
 /datum/outfit/traitor/post_equip(mob/living/carbon/human/H, visualsOnly)
 	var/obj/item/melee/energy/sword/sword = locate() in H.held_items
 	if(sword.flags_1 & INITIALIZED_1)
@@ -390,4 +363,53 @@
 		sword.worn_icon_state = "e_sword_on_red"
 
 		H.update_held_items()
+*/
 
+GLOBAL_LIST_INIT(syndicate_agent_objectives, list(
+		/datum/objective/recruitment_drive,
+		/datum/objective/limb_repo,
+		/datum/objective/organ_repo,
+		/datum/objective/fundraiser,
+		/datum/objective/hostile_environment,
+		/datum/objective/killswitch_mass,
+		/datum/objective/killswitch_target,
+	))
+/datum/objective/recruitment_drive
+	name = "recruitment drive"
+	explanation_text = "Recruit as many people to the Syndicate's cause as possible, by any means necessary."
+	martyr_compatible = TRUE
+
+/datum/objective/limb_repo
+	name = "limb repossession"
+	explanation_text = "Dismember, collect and repossess two arms from the station crew."
+	martyr_compatible = TRUE
+/datum/objective/limb_repo/New(text)
+	. = ..()	
+	var/number = pick(list(2, 3, 4))
+	var/limbs = pick(list("arms", "legs"))
+	text = "Dismember, collect and reposses [number] [limbs] from [target.name]."
+
+/datum/objective/organ_repo
+	name = "organ repossession"
+	explanation_text = "Disembowel, collect and repossess a liver from the station crew."
+	martyr_compatible = TRUE
+
+/datum/objective/fundraiser
+	name = "fundraiser"
+	explanation_text = "Collect as many credits from the station as you can, by any means necessary."
+	martyr_compatible = TRUE
+
+/datum/objective/hostile_environment
+	name = "hostile environment"
+	explanation_text = "Make the station utterly uninhabitable for human life."
+	martyr_compatible = TRUE
+
+/datum/objective/killswitch_mass
+	name = "mass killswitch implanting"
+	explanation_text = "Implant as many crewmembers with the killswitch implant as possible."
+	martyr_compatible = TRUE
+
+/datum/objective/killswitch_target
+	name = "targeted killswitch implanting"
+	explanation_text = "Implant someone with the killswitch implant and ensure they escape with it alive."
+	martyr_compatible = TRUE

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -226,6 +226,13 @@
 		main_objective.completed = TRUE
 		objectives += main_objective
 
+	if(prob(60))
+		var/datum/objective/steal/steal_objective = new
+		steal_objective.owner = owner
+		steal_objective.find_target()
+		steal_objective.completed = TRUE
+		objectives += steal_objective
+
 	var/datum/objective/objective_escape
 	var/random_escape = pick_weight(list(
 		/datum/objective/escape = 50,

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/midround_scoundrel.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/midround_scoundrel.ts
@@ -1,0 +1,18 @@
+import { Antagonist, Category } from '../base';
+import { SCOUNDREL_MECHANICAL_DESCRIPTION } from './scoundrel';
+import { multiline } from 'common/string';
+
+const Troublemaker: Antagonist = {
+  key: 'troublemaker',
+  name: 'Troublemaker',
+  description: [
+    multiline`
+      When you've had enough of dignity and just want to cause problems,
+      give in to your desire to shake things up.
+    `,
+    SCOUNDREL_MECHANICAL_DESCRIPTION,
+  ],
+  category: Category.Midround,
+};
+
+export default Troublemaker;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/traitor.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/traitor.ts
@@ -2,18 +2,19 @@ import { Antagonist, Category } from '../base';
 import { multiline } from 'common/string';
 
 export const TRAITOR_MECHANICAL_DESCRIPTION = multiline`
-      Start with an uplink to purchase your gear and take on your sinister
-      objectives. Ascend through the ranks and become an infamous legend.
+      Start with a Syndicate uplink loaded with high-grade gear, and use
+      it to take on dubious, dangerous covert objectives that may pit you
+      against the station crew.
    `;
 
 const Traitor: Antagonist = {
   key: 'traitor',
-  name: 'Traitor',
+  name: 'Syndicate Agent',
   description: [
     multiline`
-      An unpaid debt. A score to be settled. Maybe you were just in the wrong
-      place at the wrong time. Whatever the reasons, you were selected to
-      infiltrate Space Station 13.
+      An independent agent of the Syndicate. Be it for idealistic principle,
+      personal gain, or maybe as a punishment, you've been employed to carry
+      out the goals of the Syndicate. Out here, of all places.
     `,
     TRAITOR_MECHANICAL_DESCRIPTION,
   ],


### PR DESCRIPTION

## About The Pull Request
Traitor objectives have been replaced with some more interesting things, and scoundrels can now emerge as midround Troublemakers.
## Why It's Good For The Game
## Changelog
:cl:
add: new traitor objectives and preference menu flavoring
add: added Troublemakers, scoundrel midrounds
/:cl:
