### PR TITLE
Adds the bikehorn to the clown gear

### DIFF
--- a/code/game/objects/items/storage/boxes/fashion_boxes.dm
+++ b/code/game/objects/items/storage/boxes/fashion_boxes.dm
@@ -23,7 +23,7 @@
 
 /obj/item/storage/box/fashion/janitor
 	name = "janitor outfit"
-	desc = "Some durable, moisture-resistant cleaning apparel."	
+	desc = "Some durable, moisture-resistant cleaning apparel."
 /obj/item/storage/box/fashion/janitor/PopulateContents()
 	new /obj/item/clothing/under/rank/civilian/janitor(src)
 	new /obj/item/clothing/mask/bandana/purple(src)
@@ -113,7 +113,7 @@
 	new /obj/item/clothing/mask/gas/clown_hat(src)
 	new /obj/item/clothing/shoes/clown_shoes(src)
 	new /obj/item/stamp/clown(src)
-
+	new /obj/item/bikehorn(src)
 
 /obj/item/storage/box/fashion/mime
 	name = "mime outfit"


### PR DESCRIPTION

## About The Pull Request

Bike horns are key pieces of clown gear. So I added it to the clown gear you can call in.

## Why It's Good For The Game

HONK :0)

## Changelog
:cl:
add: Adds a clown's most important piece of equipment for clowning: the bike horn.
/:cl:
