### PR TITLE
Dual energy sword nerf

### DIFF
--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -26,10 +26,11 @@
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF
-	bare_wound_bonus = 20
+	wound_bonus = 10
+	bare_wound_bonus = 10
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	var/saber_color = "green"
-	var/two_hand_force = 25
+	var/two_hand_force = 20
 	var/hacked = FALSE
 	var/list/possible_colors = list("red", "blue", "green", "purple")
 

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -68,8 +68,8 @@
 			all energy projectiles, but requires two hands to wield."
 	progression_minimum = 30 MINUTES
 	item = /obj/item/dualsaber
-
-	cost = 35
+	cost = 60
+	cant_discount = TRUE // it combos hard
 	purchasable_from = ~UPLINK_CLOWN_OPS
 
 /datum/uplink_item/dangerous/doublesword/get_discount()


### PR DESCRIPTION

## About The Pull Request
Due to some oversights, the price of the desword was way lower than it should've been. Also bumped down the damage to match the esword.
## Why It's Good For The Game
## Changelog
:cl:
balance: desword damage reduced from 25 to 20
balance: desword uplink price raised from 35 to 60
balance: desword will no longer go on discount
/:cl:
