### PR TITLE
Fixes check_shields not passing both normal and stamina damage from projectiles

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -90,7 +90,8 @@
 
 				return BULLET_ACT_FORCE_PIERCE // complete projectile permutation
 
-		if(check_shields(P, P.damage, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration))
+		var/bullet_damage_total = (P.damage + P.stamina) //adds normal damage AND stamina damage from the bullet together
+		if(check_shields(P, bullet_damage_total, "the [P.name]", PROJECTILE_ATTACK, P.armour_penetration))
 			P.on_hit(src, 100, def_zone, piercing_hit)
 			return BULLET_ACT_HIT
 

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -29,10 +29,6 @@
 /obj/item/gun/ballistic/automatic/pistol/toy/riot
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol/riot
 
-/obj/item/gun/ballistic/automatic/pistol/riot/Initialize(mapload)
-	magazine = new /obj/item/ammo_box/magazine/toy/pistol/riot(src)
-	return ..()
-
 /obj/item/gun/ballistic/shotgun/toy
 	name = "foam force shotgun"
 	desc = "A toy shotgun with wood furniture and a four-shell capacity underneath. Ages 8 and up."


### PR DESCRIPTION

## About The Pull Request

As the title. Also fixes some kind of broken subtype? I guess?

## Why It's Good For The Game

we want shields to block projectiles with multiple different types of damage. Currently, shields block mixed damage projectiles exceptionally well.

## Changelog
:cl:
fix: Fixes shields blocking mixed damage projectiles too well.
fix: Removes a weird broken subtype of the pistol?
/:cl:
