### PR TITLE
EMP balance

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -361,7 +361,8 @@
 	if(. & EMP_PROTECT_CONTENTS)
 		return
 	for(var/obj/item/organ/internal_organ as anything in internal_organs)
-		internal_organ.emp_act(severity)
+		if(prob(25))
+			internal_organ.emp_act(severity)
 
 ///Adds to the parent by also adding functionality to propagate shocks through pulling and doing some fluff effects.
 /mob/living/carbon/electrocute_act(shock_damage, source, siemens_coeff = 1, flags = NONE)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -361,8 +361,7 @@
 	if(. & EMP_PROTECT_CONTENTS)
 		return
 	for(var/obj/item/organ/internal_organ as anything in internal_organs)
-		if(prob(25))
-			internal_organ.emp_act(severity)
+		internal_organ.emp_act(severity)
 
 ///Adds to the parent by also adding functionality to propagate shocks through pulling and doing some fluff effects.
 /mob/living/carbon/electrocute_act(shock_damage, source, siemens_coeff = 1, flags = NONE)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -524,11 +524,13 @@
 				informed = TRUE
 			switch(severity)
 				if(1)
-					L.receive_damage(0,10)
-					Paralyze(200)
+					L.receive_damage(0,1,3) // up to 6 burn and 18 stamina
+					electrocution_animation(1 SECONDS)
+					do_sparks(2, FALSE, src)
 				if(2)
-					L.receive_damage(0,5)
-					Paralyze(100)
+					L.receive_damage(0,1,2) // up to 6 burn and 12 stamina
+					electrocution_animation(0.5 SECONDS)
+					do_sparks(1, FALSE, src)
 
 /mob/living/carbon/human/acid_act(acidpwr, acid_volume, bodyzone_hit) //todo: update this to utilize check_obscured_slots() //and make sure it's check_obscured_slots(TRUE) to stop aciding through visors etc
 	var/list/damaged = list()

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -310,7 +310,7 @@
 		if(affecting.heal_damage(brute_heal, burn_heal, 0, BODYTYPE_ROBOTIC))
 			human.update_damage_overlays()
 		user.visible_message(span_notice("[user] fixes some of the [brute_damage ? "dents on" : "burnt wires in"] [human]'s [affecting.name]."), \
-			span_notice("You fix some of the [brute_damage ? "dents on" : "burnt wires in"] [human == user ? "your" : "[human]'s"]	[affecting.name]."))
+			span_notice("You fix some of the [brute_damage ? "dents on" : "burnt wires in"] [human == user ? "your" : "[human]'s"] [affecting.name]."))
 		return TRUE //successful heal
 
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -96,7 +96,8 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF || status == ORGAN_ROBOTIC)
 		return
-	if(prob(25/severity) && owner)
+	if(prob(25 / severity) && owner)
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 		to_chat(owner, span_warning("\The [src] is malfunctioning!"))
 		Retract()
 
@@ -194,12 +195,13 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(prob(25/severity) && owner)
+	if(prob(25 / severity) && owner)
 		Retract()
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 		to_chat(owner, span_userdanger("You feel burning inside your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm, and realize it's overheating!"))
-		owner.adjust_fire_stacks(20)
+		owner.adjust_fire_stacks(5)
 		owner.ignite_mob()
-		owner.adjustFireLoss(25)
+		owner.adjustFireLoss(rand(5,15))
 
 /obj/item/organ/internal/cyberimp/arm/gun/laser
 	name = "arm-mounted laser implant"

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -96,9 +96,8 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF || status == ORGAN_ROBOTIC)
 		return
-	if(prob(15/severity) && owner)
-		to_chat(owner, span_warning("The electromagnetic pulse causes [src] to malfunction!"))
-		// give the owner an idea about why his implant is glitching
+	if(prob(25/severity) && owner)
+		to_chat(owner, span_warning("\The [src] is malfunctioning!"))
 		Retract()
 
 /**
@@ -195,16 +194,12 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(prob(30/severity) && owner && !(organ_flags & ORGAN_FAILING))
+	if(prob(25/severity) && owner)
 		Retract()
-		owner.visible_message(span_danger("A loud bang comes from [owner]\'s [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm!"))
-		playsound(get_turf(owner), 'sound/weapons/flashbang.ogg', 100, TRUE)
-		to_chat(owner, span_userdanger("You feel an explosion erupt inside your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm as your implant breaks!"))
+		to_chat(owner, span_userdanger("You feel burning inside your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm, and realize it's overheating!"))
 		owner.adjust_fire_stacks(20)
 		owner.ignite_mob()
 		owner.adjustFireLoss(25)
-		organ_flags |= ORGAN_FAILING
-
 
 /obj/item/organ/internal/cyberimp/arm/gun/laser
 	name = "arm-mounted laser implant"

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -33,6 +33,7 @@
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
 	owner.reagents.add_reagent(/datum/reagent/toxin/bad_food, poison_amount / severity)
+	playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 	to_chat(owner, span_warning("You feel like your insides are burning."))
 
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -100,22 +100,6 @@
 	else
 		reviver_cooldown += 20 SECONDS
 
-	if(ishuman(owner))
-		var/mob/living/carbon/human/human_owner = owner
-		if(human_owner.stat != DEAD && prob(50 / severity) && human_owner.can_heartattack())
-			human_owner.set_heartattack(TRUE)
-			to_chat(human_owner, span_userdanger("You feel a horrible agony in your chest!"))
-			addtimer(CALLBACK(src, PROC_REF(undo_heart_attack)), 600 / severity)
-
-/obj/item/organ/internal/cyberimp/chest/reviver/proc/undo_heart_attack()
-	var/mob/living/carbon/human/human_owner = owner
-	if(!istype(human_owner))
-		return
-	human_owner.set_heartattack(FALSE)
-	if(human_owner.stat == CONSCIOUS)
-		to_chat(human_owner, span_notice("You feel your heart beating again!"))
-
-
 /obj/item/organ/internal/cyberimp/chest/thrusters
 	name = "implantable thrusters set"
 	desc = "An implantable set of thruster ports. They use the gas from environment or subject's internals for propulsion in zero-gravity areas. \

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -34,6 +34,7 @@
 		return
 	var/stun_amount = 2 SECONDS / severity
 	if(prob(25 / severity))
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 		owner.Knockdown(stun_amount)
 		to_chat(owner, span_warning("Your body briefly locks up!"))
 
@@ -150,7 +151,8 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	if(prob(25/severity))
+	if(prob(25 / severity))
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 		to_chat(owner, span_warning("Your breathing tube suddenly closes!"))
 		owner.losebreath += 6
 

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -32,9 +32,10 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	var/stun_amount = 200/severity
-	owner.Stun(stun_amount)
-	to_chat(owner, span_warning("Your body seizes up!"))
+	var/stun_amount = 2 SECONDS / severity
+	if(prob(25 / severity))
+		owner.Knockdown(stun_amount)
+		to_chat(owner, span_warning("Your body briefly locks up!"))
 
 
 /obj/item/organ/internal/cyberimp/brain/anti_drop
@@ -134,16 +135,6 @@
 		owner.SetImmobilized(0)
 		owner.SetParalyzed(0)
 
-/obj/item/organ/internal/cyberimp/brain/anti_stun/emp_act(severity)
-	. = ..()
-	if((organ_flags & ORGAN_FAILING) || . & EMP_PROTECT_SELF)
-		return
-	organ_flags |= ORGAN_FAILING
-	addtimer(CALLBACK(src, PROC_REF(reboot)), 90 / severity)
-
-/obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
-	organ_flags &= ~ORGAN_FAILING
-
 //[[[[MOUTH]]]]
 /obj/item/organ/internal/cyberimp/mouth
 	zone = BODY_ZONE_PRECISE_MOUTH
@@ -159,9 +150,9 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	if(prob(60/severity))
+	if(prob(25/severity))
 		to_chat(owner, span_warning("Your breathing tube suddenly closes!"))
-		owner.losebreath += 2
+		owner.losebreath += 6
 
 //BOX O' IMPLANTS
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -108,7 +108,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	applyOrganDamage(40/severity)
+	applyOrganDamage(10/severity)
 
 /obj/item/organ/internal/ears/penguin
 	name = "penguin ears"

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -108,7 +108,9 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	applyOrganDamage(10/severity)
+	if(prob(25 / severity))
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
+		applyOrganDamage(10/severity)
 
 /obj/item/organ/internal/ears/penguin
 	name = "penguin ears"
@@ -149,5 +151,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	applyOrganDamage(10/severity)
+	if(prob(25 / severity))
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
+		applyOrganDamage(10/severity)
 

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -149,5 +149,5 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	applyOrganDamage(40/severity)
+	applyOrganDamage(10/severity)
 

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -218,7 +218,7 @@
 	. = ..()
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
-	if(prob(10 * severity))
+	if(prob(5 / severity))
 		return
 	to_chat(owner, span_warning("Static obfuscates your vision!"))
 	owner.flash_act(visual = 1)
@@ -234,8 +234,8 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(prob(10 * severity))
-		applyOrganDamage(20 * severity)
+	if(prob(10 / severity))
+		applyOrganDamage(10 / severity)
 		to_chat(owner, span_warning("Your eyes start to fizzle in their sockets!"))
 		do_sparks(2, TRUE, owner)
 		owner.emote("scream")

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -219,9 +219,9 @@
 	if(!owner || . & EMP_PROTECT_SELF)
 		return
 	if(prob(5 / severity))
-		return
-	to_chat(owner, span_warning("Static obfuscates your vision!"))
-	owner.flash_act(visual = 1)
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
+		to_chat(owner, span_warning("Static obfuscates your vision!"))
+		owner.flash_act(visual = 1)
 
 /obj/item/organ/internal/eyes/robotic/basic
 	name = "basic robotic eyes"
@@ -235,6 +235,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(prob(10 / severity))
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 		applyOrganDamage(10 / severity)
 		to_chat(owner, span_warning("Your eyes start to fizzle in their sockets!"))
 		do_sparks(2, TRUE, owner)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -221,6 +221,7 @@
 	if(. & EMP_PROTECT_SELF)
 		return
 	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
+		playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
 		owner.set_dizzy_if_lower(20 SECONDS)
 		owner.losebreath += 10
 		COOLDOWN_START(src, severe_cooldown, 20 SECONDS)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -191,7 +191,7 @@
 	var/dose_available = FALSE
 	var/rid = /datum/reagent/medicine/epinephrine
 	var/ramount = 10
-	var/emp_vulnerability = 80 //Chance of permanent effects if emp-ed.
+	var/emp_vulnerability = 40 //Chance of permanent effects if emp-ed.
 
 /obj/item/organ/internal/heart/cybernetic/tier2
 	name = "cybernetic heart"
@@ -200,7 +200,7 @@
 	base_icon_state = "heart-c-u"
 	maxHealth = 1.5 * STANDARD_ORGAN_THRESHOLD
 	dose_available = TRUE
-	emp_vulnerability = 40
+	emp_vulnerability = 20
 
 /obj/item/organ/internal/heart/cybernetic/tier3
 	name = "upgraded cybernetic heart"
@@ -209,7 +209,7 @@
 	base_icon_state = "heart-c-u2"
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	dose_available = TRUE
-	emp_vulnerability = 20
+	emp_vulnerability = 10
 
 /obj/item/organ/internal/heart/cybernetic/emp_act(severity)
 	. = ..()
@@ -229,7 +229,7 @@
 		Stop()
 		owner.visible_message(span_danger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"), \
 						span_userdanger("You feel a terrible pain in your chest, as if your heart has stopped!"))
-		addtimer(CALLBACK(src, PROC_REF(Restart)), 10 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(Restart)), 1 SECONDS)
 
 /obj/item/organ/internal/heart/cybernetic/on_life(delta_time, times_fired)
 	. = ..()

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -226,10 +226,14 @@
 		COOLDOWN_START(src, severe_cooldown, 20 SECONDS)
 	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
 		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
+
+// EMPs really don't need random stuns like this to be useful
+/*
 		Stop()
 		owner.visible_message(span_danger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"), \
 						span_userdanger("You feel a terrible pain in your chest, as if your heart has stopped!"))
 		addtimer(CALLBACK(src, PROC_REF(Restart)), 1 SECONDS)
+*/
 
 /obj/item/organ/internal/heart/cybernetic/on_life(delta_time, times_fired)
 	. = ..()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -265,8 +265,10 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
-		owner.adjustToxLoss(10)
-		COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
+	if(prob(25 / severity))
+		if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
+			playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
+			owner.adjustToxLoss(10)
+			COOLDOWN_START(src, severe_cooldown, 10 SECONDS)
+		if(prob(emp_vulnerability/severity)) //Chance of permanent effects
+			organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -604,11 +604,13 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
-		owner.losebreath += 20
-		COOLDOWN_START(src, severe_cooldown, 30 SECONDS)
-	if(prob(emp_vulnerability/severity)) //Chance of permanent effects
-		organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
+	if(prob(25 / severity))
+		if(!COOLDOWN_FINISHED(src, severe_cooldown)) //So we cant just spam emp to kill people.
+			playsound(owner, 'sound/weapons/ionrifle.ogg', 50, TRUE, -1)
+			owner.losebreath += 10
+			COOLDOWN_START(src, severe_cooldown, 30 SECONDS)
+		if(prob(emp_vulnerability/severity)) //Chance of permanent effects
+			organ_flags |= ORGAN_SYNTHETIC_EMP //Starts organ faliure - gonna need replacing soon.
 
 
 /obj/item/organ/internal/lungs/ashwalker


### PR DESCRIPTION
## About The Pull Request
Makes EMPS significantly less punishing
## Why It's Good For The Game
EMPs no longer being instant death means both they and cybernetics can be a regular and interesting part of the game, rather than an outlier that only serves to invalidate niche features
## Changelog
:cl:
balance: EMPs no longer immediately stun, and do stamina & burn damage scaling with the number of limbs effected
balance: almost every organ with an EMP effect has been rebalanced to take into account probably checks
balance: all organs that had a chance to hardstun or kill you with a single proc have had that feature removed
spellcheck: fixed a robotic limb healing readout
/:cl:
