### PR TITLE
Damage slowdown balance

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -103,6 +103,13 @@
 //slowdown when crawling
 #define CRAWLING_ADD_SLOWDOWN 4
 
+//Human damage slowdown stats
+//Having this amount of cumulative damage will apply a slowdown to humans
+#define H_DAMAGE_SLOWDOWN_THRESHOLD 40
+//Damage slowdown is scales with the amount of damage cumulatively, and is then divided by these numbers
+#define H_DAMAGE_SLOWDOWN_DIVIDEBY 100
+#define H_DAMAGE_SLOWDOWN_DIVIDEBY_FLYING 125
+
 //Attack types for checking shields/hit reactions
 #define MELEE_ATTACK 1
 #define UNARMED_ATTACK 2

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -955,9 +955,9 @@
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 		return
 	var/health_deficiency = ((maxHealth - health) + staminaloss)
-	if(health_deficiency >= 40)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)
+	if(health_deficiency >= H_DAMAGE_SLOWDOWN_THRESHOLD)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / H_DAMAGE_SLOWDOWN_DIVIDEBY)
+		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / H_DAMAGE_SLOWDOWN_DIVIDEBY_FLYING)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)


### PR DESCRIPTION

## About The Pull Request
see changelog
## Why It's Good For The Game
I think the severe slowdown penalty benefits alpha strike too much and shuts down what could be interesting evasive gameplay. If you need to slow someone down, there's a lot of ways to accomplish that, like:
Bolas, targeting their leg, freezing them, etc.
## Changelog
:cl:
qol: added documented defines pertaining to damage slowdown factors
balance: the scaling damage slowdown factor has been adjusted so players should experience a more gradual slowdown, and not take as much punishment for crossing the 40 damage threshold
fix: flying should now appropriately have a reduced damage slowdown
/:cl:
