### PR TITLE
Disable bloodbrothers

### DIFF
--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -34,7 +34,7 @@
 		},
 
 		"Blood Brothers": {
-			"weight": 5
+			"weight": 0
 		},
 
 		"Changelings": {


### PR DESCRIPTION

## About The Pull Request
turns bloodbrothers off
## Why It's Good For The Game
it needs some improvement and treatment before it can be a healthy part of the game
## Changelog
:cl:
config: bloodbrother disabled in config
/:cl:
