### PR TITLE
Master ID access fix

### DIFF
--- a/code/datums/id_trim/scoundrel_trim.dm
+++ b/code/datums/id_trim/scoundrel_trim.dm
@@ -212,3 +212,10 @@
 		ACCESS_CAPTAIN,
 		ACCESS_CHANGE_IDS,
 		)
+/datum/id_trim/job/master/New()
+	extra_access |= (SSid_access.get_flag_access_list(ACCESS_FLAG_COMMON) + SSid_access.get_flag_access_list(ACCESS_FLAG_COMMAND))
+	extra_wildcard_access |= (SSid_access.get_flag_access_list(ACCESS_FLAG_PRV_COMMAND) + SSid_access.get_flag_access_list(ACCESS_FLAG_CAPTAIN))
+	minimal_access |= (SSid_access.get_flag_access_list(ACCESS_FLAG_COMMON) + SSid_access.get_flag_access_list(ACCESS_FLAG_COMMAND))
+	minimal_wildcard_access |= (SSid_access.get_flag_access_list(ACCESS_FLAG_PRV_COMMAND) + SSid_access.get_flag_access_list(ACCESS_FLAG_CAPTAIN))
+
+	return ..()


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game
## Changelog
:cl:
fix: the master ID card found in the vault's safe should now have the access it's supposed to
/:cl:
