### PR TITLE
Fireaxe windowbreaking balance

### DIFF
--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -54,7 +54,14 @@
 	if(HAS_TRAIT(src, TRAIT_WIELDED)) //destroys windows and grilles in one hit
 		if(istype(A, /obj/structure/window) || istype(A, /obj/structure/grille))
 			var/obj/structure/W = A
-			W.atom_destruction("fireaxe")
+			var/base_damage = force * demolition_mod
+			// if a third of the atom's max_integrity is greater than the damage the axe deals normally
+			if(W.max_integrity / 3 > base_damage)
+				// find the difference between a third of the atom's max_integrity and the axe's base damage
+				var/additive_damage = round((W.max_integrity / 3) - base_damage) + 1
+				// so it deals an amount cumulative to a third of the atom's max_integrity
+				W.take_damage(additive_damage)
+				// in effect, it will always deal at least a third of a window's max health per hit
 
 /*
  * Bone Axe


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game
It's just too effective as a sabotage tool. This adjustment should keep that in check without depleting its utility too drastically.
## Changelog
:cl:
balance: fireaxes now deal a third of a window's max integrity, or their base damage, depending on whichever is higher
balance: that means it takes 3 hits to break a window with a fireaxe now
/:cl:
