### PR TITLE
Wallet stuff

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -119,7 +119,7 @@
 
 	register_context()
 
-	RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, PROC_REF(update_in_wallet))
+//	RegisterSignal(src, COMSIG_ATOM_UPDATED_ICON, PROC_REF(update_in_wallet))
 	if(prob(1))
 		ADD_TRAIT(src, TRAIT_TASTEFULLY_THICK_ID_CARD, ROUNDSTART_TRAIT)
 
@@ -132,7 +132,7 @@
 
 /obj/item/card/id/get_id_examine_strings(mob/user)
 	. = ..()
-	. += list("[icon2html(get_cached_flat_icon(), user, extra_classes = "bigicon")]")
+//	. += list("[icon2html(get_cached_flat_icon(), user, extra_classes = "bigicon")]")
 
 /obj/item/card/id/update_overlays()
 	. = ..()
@@ -757,6 +757,7 @@
 /obj/item/card/id/RemoveID()
 	return src
 
+/*
 /// Called on COMSIG_ATOM_UPDATED_ICON. Updates the visuals of the wallet this card is in.
 /obj/item/card/id/proc/update_in_wallet()
 	SIGNAL_HANDLER
@@ -766,6 +767,7 @@
 		if(powergaming.front_id == src)
 			powergaming.update_label()
 			powergaming.update_appearance()
+*/ // used by wallets in disabled features
 
 /// Updates the name based on the card's vars and state.
 /obj/item/card/id/proc/update_label()

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -80,7 +80,7 @@
 		if(wearing_human.wear_id == src)
 			wearing_human.sec_hud_set_ID()
 
-	update_label()
+//	update_label()
 	update_appearance(UPDATE_ICON)
 	update_slot_icon()
 
@@ -88,7 +88,7 @@
 	. = ..()
 	if(isidcard(arrived))
 		refreshID()
-
+/*
 /obj/item/storage/wallet/update_overlays()
 	. = ..()
 	cached_flat_icon = null
@@ -97,6 +97,7 @@
 	. += mutable_appearance(front_id.icon, front_id.icon_state)
 	. += front_id.overlays
 	. += mutable_appearance(icon, "wallet_overlay")
+*/ // anonymity is fine
 
 /obj/item/storage/wallet/proc/get_cached_flat_icon()
 	if(!cached_flat_icon)
@@ -108,16 +109,20 @@
 		return "[icon2html(get_cached_flat_icon(), user)] [thats? "That's ":""][get_examine_name(user)]" //displays all overlays in chat
 	return ..()
 
+/*
 /obj/item/storage/wallet/proc/update_label()
 	if(front_id)
 		name = "wallet displaying [front_id]"
 	else
 		name = "wallet"
+*/ // anonymity is fine. if you want to turn this back on, look for "powergaming.update_label"
 
+/*
 /obj/item/storage/wallet/examine()
 	. = ..()
 	if(front_id)
 		. += span_notice("Alt-click to remove the id.")
+*/ // no longer true, and for the best that way
 
 /obj/item/storage/wallet/get_id_examine_strings(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Reverts some of the overreaching, anti-player mechanics that limit any clever utility of wallets. This is a draft because I'm not entirely comfortable leaving behind derelict code pertaining to the features that have been commented away.
## Why It's Good For The Game
I strongly feel these changes were added to spite a subset of players, and I don't think there's any worthwhile principle for keeping them. Players finding clever ways to obfuscate their identity is quite fine to me, actually.
## Changelog
:cl:
del: removed wallet overlay mechanics, allowing them to hide your role once again
/:cl:
