### PR TITLE
Penthrite reaction changes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -496,7 +496,7 @@
 */
 /datum/reagent/medicine/c2/penthrite
 	name = "Penthrite"
-	description = "An expensive medicine that aids with pumping blood around the body even without a heart, and prevents the heart from slowing down. Mixing it with epinephrine or atropine will cause an explosion."
+	description = "An expensive medicine that aids with pumping blood around the body even without a heart, and prevents the heart from slowing down. Mixing it with epinephrine or atropine will create cyanide."
 	color = "#F5F5F5"
 	overdose_threshold = 50
 	ph = 12.7

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -931,3 +931,16 @@
 	for(var/i in rand(1, created_volume) to created_volume)
 		new /mob/living/simple_animal/hostile/ant(location)
 	..()
+
+// scoundrel content
+/datum/chemical_reaction/penthrite_reaction_epinephrine
+	required_reagents = list(/datum/reagent/medicine/c2/penthrite = 1, /datum/reagent/medicine/epinephrine = 1)
+	results = list(/datum/reagent/toxin/cyanide = 2)
+	reaction_flags = REACTION_INSTANT
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/penthrite_reaction_atropine
+	required_reagents = list(/datum/reagent/medicine/c2/penthrite = 1, /datum/reagent/medicine/atropine = 1)
+	results = list(/datum/reagent/toxin/cyanide = 2)
+	reaction_flags = REACTION_INSTANT
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -100,15 +100,6 @@
 /datum/chemical_reaction/reagent_explosion/tatp_explosion/update_info()
 	required_temp = 550 + rand(-49,49)
 
-/datum/chemical_reaction/reagent_explosion/penthrite_explosion_epinephrine
-	required_reagents = list(/datum/reagent/medicine/c2/penthrite = 1, /datum/reagent/medicine/epinephrine = 1)
-	strengthdiv = 5
-
-/datum/chemical_reaction/reagent_explosion/penthrite_explosion_atropine
-	required_reagents = list(/datum/reagent/medicine/c2/penthrite = 1, /datum/reagent/medicine/atropine = 1)
-	strengthdiv = 5
-	modifier = 5
-
 /datum/chemical_reaction/reagent_explosion/potassium_explosion
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/potassium = 1)
 	strengthdiv = 20


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game
instantly blowing someone up for not knowing an easily missed detail is ridiculously anti player
## Changelog
:cl:
balance: penthrite, when mixed with epinephrine or atropine now turns into cyanide rather than exploding
balance: that means mishandled luxury medipens are no longer instant death
/:cl:
