### PR TITLE
Map update 4

### DIFF
--- a/_maps/map_files/Freebooter/Freebooter.dmm
+++ b/_maps/map_files/Freebooter/Freebooter.dmm
@@ -2037,6 +2037,7 @@
 /obj/item/clothing/head/utility/hardhat/weldhat/white,
 /obj/item/disk/surgery/brainwashing,
 /obj/item/ai_module/reset,
+/obj/item/tank/jetpack/oxygen/captain,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "ht" = (

--- a/_maps/map_files/Freebooter/Freebooter.dmm
+++ b/_maps/map_files/Freebooter/Freebooter.dmm
@@ -395,7 +395,7 @@
 /obj/structure/sign/warning/vacuum/directional/south,
 /obj/machinery/light/emergency/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "bz" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -432,9 +432,10 @@
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
 "bH" = (
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/power/smes{
+	dir = 4
+	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/computer)
 "bJ" = (
@@ -798,9 +799,9 @@
 /turf/open/floor/iron,
 /area/station/engineering)
 "cZ" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
-/turf/open/space/basic,
+/obj/machinery/power/solar,
+/turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "da" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -817,6 +818,7 @@
 /area/station/hallway/primary/fore)
 "dd" = (
 /obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
 "df" = (
@@ -876,6 +878,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/north,
 /obj/item/gun/energy/laser/practice,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/range)
 "dp" = (
@@ -1376,7 +1379,8 @@
 /obj/machinery/power/apc/auto_name/directional/north{
 	start_charge = 0
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "fm" = (
@@ -1400,6 +1404,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical)
+"fo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port)
 "fp" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -1426,9 +1434,10 @@
 /area/space/nearstation/nostarlight)
 "ft" = (
 /obj/structure/cable,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation/nostarlight)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "fu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -1483,10 +1492,13 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/research/abandoned)
 "fB" = (
-/obj/item/stack/rods,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation/nostarlight)
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "fC" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 4
@@ -1989,7 +2001,13 @@
 /area/station/service/cafeteria)
 "hr" = (
 /obj/structure/sign/clock/directional/north,
-/obj/machinery/suit_storage_unit/captain,
+/obj/structure/closet/secure_closet/captain_scoundrel,
+/obj/item/clothing/neck/stethoscope,
+/obj/item/pinpointer/nuke,
+/obj/item/circuitboard/computer/communications,
+/obj/item/clothing/head/utility/hardhat/weldhat/white,
+/obj/item/disk/surgery/brainwashing,
+/obj/item/ai_module/reset,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "ht" = (
@@ -2166,7 +2184,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "hT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2271,6 +2289,11 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"io" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "ip" = (
 /obj/machinery/computer/operating,
 /obj/machinery/airalarm/directional/north,
@@ -2382,7 +2405,7 @@
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "iN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light/directional/west,
@@ -2390,16 +2413,12 @@
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "iO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "iQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
@@ -2495,9 +2514,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "ji" = (
-/obj/item/stack/rods,
-/turf/open/space/basic,
-/area/space)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "jj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
@@ -2525,6 +2545,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/sign/warning/explosives/alt/directional/north,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "jp" = (
@@ -2588,6 +2609,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"jA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/science/research/abandoned)
 "jB" = (
 /obj/machinery/ai_slipper,
 /turf/open/floor/engine,
@@ -2666,6 +2691,11 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
+"jP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "jQ" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -2860,9 +2890,12 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kz" = (
-/obj/item/stack/rods/two,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "kA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -2987,6 +3020,10 @@
 /obj/item/pen/screwdriver,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
+"la" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "lb" = (
 /obj/vehicle/ridden/scooter,
 /obj/effect/decal/cleanable/blood/old,
@@ -3135,10 +3172,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "ly" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/machinery/suit_storage_unit/starsuit/engineering,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "lz" = (
 /obj/docking_port/stationary/mining_home/kilo,
 /turf/open/space/basic,
@@ -3322,6 +3358,7 @@
 	pixel_x = 6
 	},
 /obj/machinery/light/emergency/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
 "mk" = (
@@ -3379,10 +3416,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
 "ms" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "mt" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -3452,6 +3492,14 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/fitness)
+"mI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "mJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -3549,6 +3597,7 @@
 "ng" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/autoname/directional/west,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
 "nh" = (
@@ -3639,7 +3688,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "nw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -3672,9 +3721,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "nD" = (
-/obj/item/stack/cable_coil,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research/abandoned)
 "nE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/directional/south,
@@ -3793,6 +3843,18 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
+"oa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "ob" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3909,6 +3971,9 @@
 "oB" = (
 /obj/machinery/camera/motion/directional/north,
 /obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/computer)
 "oC" = (
@@ -3999,6 +4064,7 @@
 /area/station/maintenance/department/engine/atmos)
 "oS" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/cup/bottle/formaldehyde,
 /turf/open/floor/iron/white,
 /area/station/medical)
 "oT" = (
@@ -4101,7 +4167,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "pm" = (
 /obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/emergency/directional/north,
@@ -4133,6 +4199,7 @@
 /area/space/nearstation)
 "pr" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "ps" = (
@@ -4339,6 +4406,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/storage)
+"qa" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "qb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -4793,6 +4864,18 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/smooth_half,
 /area/awaymission/secret/powered)
+"rx" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/emergency/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "ry" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
@@ -4859,7 +4942,7 @@
 	dir = 1
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "rO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -5004,7 +5087,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "ss" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -5184,15 +5267,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "tf" = (
-/obj/item/ai_module/reset,
-/obj/item/clothing/neck/stethoscope,
-/obj/item/pinpointer/nuke,
-/obj/item/disk/surgery/brainwashing,
-/obj/item/clothing/head/utility/hardhat/weldhat/white,
-/obj/item/circuitboard/computer/communications,
-/obj/item/clothing/suit/toggle/jacket,
-/obj/structure/closet/secure_closet/captain_scoundrel,
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/suit_storage_unit/starsuit,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
 "tj" = (
@@ -5425,6 +5501,11 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
+"ue" = (
+/obj/item/stack/rods/two,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5496,6 +5577,8 @@
 /area/station/service/kitchen)
 "ut" = (
 /obj/machinery/door/airlock/research,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "uv" = (
@@ -5531,6 +5614,11 @@
 	},
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
+"uz" = (
+/obj/item/stack/cable_coil,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "uA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5660,7 +5748,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "uY" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 1
@@ -5671,6 +5759,7 @@
 	name = "Test Site Materials Crate";
 	req_access = list("ordnance")
 	},
+/obj/structure/sign/warning/explosives/alt/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "uZ" = (
@@ -5754,7 +5843,7 @@
 /area/space/nearstation/nostarlight)
 "vm" = (
 /obj/machinery/power/smes{
-	dir = 4
+	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -5844,9 +5933,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vD" = (
-/obj/item/wirecutters,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "vE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -5860,6 +5953,12 @@
 	},
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"vI" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "vJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -6000,7 +6099,7 @@
 	pixel_y = -6
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "wm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/nightshift/directional/east,
@@ -6159,7 +6258,8 @@
 "wQ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
+	dir = 1;
+	name = "n2 pump"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -6770,8 +6870,15 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/ce)
 "zp" = (
-/turf/open/space/basic,
-/area/space/nearstation/nostarlight)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "zq" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -6965,6 +7072,12 @@
 /obj/structure/closet/secure_closet/medsci_spec,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
+"Ab" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -7404,6 +7517,10 @@
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"BG" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "BH" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured_large,
@@ -7507,6 +7624,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering)
+"Ca" = (
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Cb" = (
 /obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/floor/circuit/airless,
@@ -7646,6 +7768,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"CA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "CC" = (
 /obj/machinery/conveyor/inverted{
 	id = "garbage";
@@ -7781,12 +7910,17 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "CZ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
+"Da" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/department/crew_quarters/dorms)
 "Db" = (
 /obj/machinery/computer/operating,
 /obj/machinery/newscaster/directional/north,
@@ -7835,7 +7969,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "Do" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/holopad,
@@ -7915,6 +8049,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "DB" = (
@@ -7927,6 +8062,13 @@
 	},
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/bridge)
+"DC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "DD" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -8452,8 +8594,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
+"Fu" = (
+/obj/item/wirecutters,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "Fx" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plating,
 /area/station/engineering)
 "Fy" = (
@@ -8617,6 +8764,7 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
 	},
+/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
 "Gg" = (
@@ -8701,10 +8849,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
 "Gu" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil/one,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/structure/cable,
+/turf/open/floor/plating/airless,
 /area/space/nearstation/nostarlight)
 "Gv" = (
 /obj/machinery/status_display/door_timer{
@@ -8746,8 +8892,7 @@
 /area/station/engineering/gravity_generator)
 "GC" = (
 /obj/item/stack/cable_coil/one,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/space/nearstation/nostarlight)
 "GD" = (
 /turf/open/floor/iron/dark/textured_large,
@@ -8818,6 +8963,7 @@
 /area/space/nearstation)
 "GR" = (
 /obj/item/kirbyplants/photosynthetic,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/fitness)
 "GS" = (
@@ -8839,7 +8985,7 @@
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "GU" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -8847,6 +8993,7 @@
 "GW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm/directional/south,
+/obj/structure/window/spawner/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/hydroponics/garden)
 "GX" = (
@@ -9075,6 +9222,7 @@
 /obj/structure/toilet{
 	pixel_y = 17
 	},
+/obj/machinery/light/small/nightshift/directional/east,
 /turf/open/floor/iron/smooth_half,
 /area/station/maintenance/department/cargo)
 "HO" = (
@@ -9326,6 +9474,7 @@
 	},
 /obj/machinery/chem_heater,
 /obj/item/storage/box/beakers,
+/obj/item/reagent_containers/cup/bottle/basic_buffer,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical)
 "ID" = (
@@ -9623,6 +9772,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/tcommsat/computer)
 "JM" = (
@@ -9713,7 +9863,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "Kh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10095,9 +10245,18 @@
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "LA" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
+"LB" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/hydroponics/garden)
 "LC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10113,6 +10272,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"LF" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "LG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -10543,6 +10708,10 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
+"Nb" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/tcommsat/computer)
 "Nc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10801,8 +10970,7 @@
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
 "NZ" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/space/nearstation/nostarlight)
 "Oa" = (
 /obj/machinery/button/door/directional/west{
@@ -10854,6 +11022,7 @@
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "On" = (
@@ -10919,7 +11088,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "Ox" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output{
 	dir = 1
@@ -10951,6 +11120,10 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
+"OG" = (
+/obj/structure/railing/corner,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "OI" = (
 /obj/item/kirbyplants,
 /turf/open/floor/wood/large,
@@ -11143,14 +11316,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/lobby)
 "Pq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/turf/closed/wall,
+/area/station/maintenance/solars/starboard)
 "Pr" = (
 /obj/structure/flora/bush/sunny/style_random,
 /turf/open/floor/grass,
@@ -11188,11 +11355,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/command/heads_quarters/ce)
 "PA" = (
-/obj/structure/chair,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/north,
+/obj/machinery/destructive_scanner,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
 "PB" = (
@@ -11391,6 +11557,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/emergency/directional/east,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
 "Qx" = (
@@ -11850,6 +12017,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"So" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11859,6 +12030,7 @@
 "Sq" = (
 /obj/structure/cable,
 /obj/structure/tank_dispenser/oxygen,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/lobby)
 "St" = (
@@ -11898,6 +12070,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"SB" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "SC" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -12245,10 +12424,13 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "TP" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/cable_coil/one,
-/turf/open/space/basic,
-/area/space/nearstation/nostarlight)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "o2 pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "TQ" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -12378,6 +12560,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"Ul" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "Um" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12402,7 +12590,7 @@
 /turf/open/floor/iron/white,
 /area/station/service/chapel)
 "Us" = (
-/obj/machinery/washing_machine,
+/obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "Uu" = (
@@ -12412,7 +12600,7 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "Uv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/closet/wall{
@@ -12431,7 +12619,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12455,7 +12643,7 @@
 /area/station/security/range)
 "UH" = (
 /obj/structure/safe{
-	number_of_tumblers = 5
+	number_of_tumblers = 3
 	},
 /obj/item/toy/plush/nukeplushie,
 /obj/item/card/id/advanced/gold/captains_spare,
@@ -12524,6 +12712,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"UV" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "UW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/textured_large,
@@ -12587,6 +12781,12 @@
 "Vh" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
+"Vi" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "Vj" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -12601,7 +12801,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/awaymission/secret/powered)
 "Vo" = (
-/obj/machinery/computer/pandemic,
+/obj/structure/table,
+/obj/item/experi_scanner,
+/obj/item/experi_scanner,
+/obj/item/experi_scanner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science)
 "Vp" = (
@@ -12833,6 +13036,11 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/science)
+"Wf" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Wg" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/power/solar_control{
@@ -12840,7 +13048,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "Wh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13259,7 +13467,7 @@
 "Xz" = (
 /obj/machinery/suit_storage_unit/starsuit/engineering,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "XA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -13579,7 +13787,7 @@
 /area/station/command/heads_quarters/rd)
 "YH" = (
 /turf/closed/wall,
-/area/station/maintenance/port/aft)
+/area/station/maintenance/solars/port)
 "YJ" = (
 /obj/structure/marker_beacon/lime,
 /obj/structure/lattice/catwalk,
@@ -13726,6 +13934,11 @@
 /obj/item/knife/combat/survival,
 /turf/open/misc/asteroid/airless,
 /area/ruin/powered)
+"Zn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Zp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/north,
@@ -13737,6 +13950,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"Zr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "Zt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43614,12 +43831,12 @@ xJ
 RS
 wB
 Gj
-EU
+Da
 mt
 mt
 RC
 nt
-wB
+la
 nt
 dN
 dN
@@ -44385,10 +44602,10 @@ KI
 dN
 dN
 dN
-Pa
+tP
 dN
 dN
-Pa
+tP
 dN
 dN
 dN
@@ -44608,7 +44825,7 @@ An
 PW
 PW
 PW
-PW
+LB
 GW
 we
 cN
@@ -44636,24 +44853,24 @@ iM
 rM
 Wg
 YH
+fo
 YH
-YH
-KI
+mI
 dN
 dN
 dN
-DW
-Ig
-DW
-DW
-dh
-dh
-dh
-DW
-Ig
-DW
-dh
-dh
+tP
+dN
+dN
+tP
+dN
+dN
+dN
+dN
+dN
+dN
+dN
+dN
 dN
 dN
 dN
@@ -44896,22 +45113,22 @@ YH
 PK
 eW
 cr
+Pa
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
 dN
 dN
 dN
-dN
-pp
-dN
-dN
-dN
-dN
-dN
-dN
-pp
-dN
-dN
-dh
-dh
 dN
 dN
 dN
@@ -45150,25 +45367,25 @@ dN
 pp
 dN
 dN
-dN
-CZ
-dN
-dN
-dN
-dN
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
+pp
+eW
+pp
 dN
 dN
-dh
+pp
+dN
+dN
+dN
+dN
+dN
+dN
+pp
+dN
+dN
+Ig
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -45407,25 +45624,25 @@ dN
 pp
 dN
 dN
+pp
+eW
+pp
 dN
-CZ
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
 dN
 dN
-DW
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -45664,25 +45881,25 @@ dN
 pp
 dN
 dN
+pp
+eW
+pp
 dN
-CZ
-pp
-pp
-pp
-pp
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
-pp
-pp
+dN
+Gu
+dN
+dN
+dN
+dN
+dN
+dN
+Gu
+dN
+dN
+dN
 Ig
+dN
+dN
 dN
 dN
 dN
@@ -45921,25 +46138,25 @@ dN
 pp
 dN
 dN
+pp
+eW
+pp
+Pa
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
+pp
+pp
+Ig
 dN
-CZ
 dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-DW
 dN
 dN
 dN
@@ -46178,25 +46395,25 @@ Mi
 Mi
 dN
 dN
-dN
-CZ
-dN
-dN
-dN
-dN
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
+pp
+eW
+pp
 dN
 dN
-dh
+Gu
+dN
+dN
+dN
+dN
+dN
+dN
+Gu
+dN
+dN
+dN
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -46435,25 +46652,25 @@ dN
 Mi
 dN
 dN
+pp
+eW
+pp
 dN
-CZ
-dN
-dN
-dN
-dN
-dN
+cZ
+wo
+cZ
+cZ
+cZ
+cZ
+cZ
+cZ
+wo
 cZ
 dN
 dN
+Ig
 dN
 dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dh
 dN
 dN
 dN
@@ -46692,25 +46909,25 @@ dN
 Mi
 dN
 dN
-dN
-CZ
-dN
-dN
-dN
-dN
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
+pp
+eW
+pp
 dN
 dN
-dh
+Gu
+dN
+dN
+dN
+dN
+dN
+dN
+Gu
+dN
+dN
+dN
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -46950,24 +47167,24 @@ Mi
 Mi
 Mi
 Mi
-CZ
+eW
+ue
 dN
-ji
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
 dN
 dN
-dh
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -47206,25 +47423,25 @@ dN
 pp
 dN
 dN
+pp
+eW
+pp
+uz
+pp
+GC
+pp
+pp
+pp
+ue
+pp
+pp
+GC
+pp
+pp
 dN
-SV
+Ig
 dN
 dN
-dN
-dN
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
-dN
-dN
-dh
 dN
 dN
 dN
@@ -47463,25 +47680,25 @@ dN
 pp
 dN
 dN
-dN
-SV
-dN
-dN
-dN
-nD
-dN
+pp
+eW
+pj
+pj
+wo
+wo
+wo
 Gu
+NZ
+NZ
+NZ
+wo
+wo
+wo
+Wf
+tP
+Ig
 dN
 dN
-dN
-kz
-dN
-dN
-cZ
-dN
-dN
-dN
-DW
 dN
 dN
 dN
@@ -47720,25 +47937,25 @@ dN
 pp
 dN
 dN
-dN
-SV
-gx
-gx
-gx
-gx
-cZ
-NZ
-NZ
-fB
-tP
-zp
-NZ
-GC
-ft
-GC
-Eh
 pp
+SV
+Fu
+pp
+pp
+NZ
+pp
+pp
+pp
+pp
+pp
+pp
+NZ
+pp
+pp
+dN
 Ig
+dN
+dN
 dN
 dN
 dN
@@ -47977,25 +48194,25 @@ dN
 pp
 dN
 dN
-dN
+pp
 SV
+pp
+dN
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
 dN
 dN
-vD
+Ig
 dN
 dN
-NZ
-dN
-dN
-dN
-dN
-dN
-dN
-TP
-dN
-dN
-dN
-DW
 dN
 dN
 dN
@@ -48234,25 +48451,25 @@ dN
 pp
 dN
 dN
-dN
+pp
 SV
+pp
+dN
+dN
+NZ
 dN
 dN
 dN
 dN
-in
-pj
-in
-in
-in
-in
-in
-in
-wo
-in
 dN
 dN
-dh
+NZ
+dN
+dN
+dN
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -48491,25 +48708,25 @@ dN
 pp
 dN
 dN
-dN
+pp
 SV
+pp
+dN
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
 dN
 dN
+Ig
 dN
 dN
-dN
-NZ
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dh
 dN
 dN
 dN
@@ -48748,25 +48965,25 @@ dN
 pp
 dN
 dN
-dN
+pp
 SV
+pp
+dN
+dN
+NZ
 dN
 dN
 dN
 dN
-in
-pj
-in
-in
-in
-in
-in
-in
-wo
-in
 dN
 dN
-dh
+NZ
+dN
+dN
+dN
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -49005,25 +49222,25 @@ dN
 pp
 dN
 dN
-dN
+pp
 SV
+pp
+Pa
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pp
+pp
+Ig
 dN
 dN
-dN
-dN
-dN
-fB
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dh
 dN
 dN
 dN
@@ -49264,23 +49481,23 @@ Mi
 Mi
 Mi
 SV
+pp
+dN
+dN
+NZ
 dN
 dN
 dN
 dN
-in
-pj
-in
-in
-in
-in
-in
-in
-wo
-in
 dN
 dN
-dh
+NZ
+dN
+dN
+dN
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -49519,25 +49736,25 @@ dN
 Mi
 dN
 dN
-dN
+pp
 SV
+pp
+dN
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+pj
 dN
 dN
+Ig
 dN
 dN
-dN
-TP
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-DW
 dN
 dN
 dN
@@ -49776,25 +49993,25 @@ Mi
 Mi
 dN
 dN
-dN
+pp
 SV
 pp
+dN
+dN
 pp
+dN
+dN
+dN
+dN
+dN
+dN
 pp
-pp
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
-pp
-pp
+dN
+dN
 Ig
+Ig
+dN
+dN
 dN
 dN
 dN
@@ -50033,25 +50250,25 @@ dN
 pp
 dN
 dN
-dN
+pp
 SV
+pp
+Pa
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
+Ig
 dN
 dN
 dN
-dN
-dN
-cZ
-dN
-dN
-dN
-dN
-dN
-dN
-cZ
-dN
-dN
-dN
-DW
 dN
 dN
 dN
@@ -50290,25 +50507,25 @@ dN
 pp
 dN
 dN
-dN
+pp
+SV
 SV
 dN
 dN
 dN
 dN
-in
-wo
-in
-in
-in
-in
-in
-in
-wo
-in
 dN
 dN
-dh
+dN
+dN
+dN
+dN
+dN
+dN
+dN
+dN
+dN
+dN
 dN
 dN
 dN
@@ -50542,30 +50759,30 @@ zk
 JU
 IB
 wo
-dN
-dN
-pp
-dN
-dN
-dN
-SV
-dN
-dN
-dN
-dN
-dN
-pp
+Pa
+Pa
+Pq
+Pq
+Pq
+Pq
+Pq
+Zn
+LA
+CZ
 dN
 dN
 dN
 dN
 dN
 dN
-pp
 dN
 dN
-dh
-dh
+dN
+dN
+dN
+dN
+dN
+dN
 dN
 dN
 dN
@@ -50800,28 +51017,28 @@ SO
 IB
 ym
 ys
-dN
-RL
-ca
-ca
-VY
-SV
-dN
-dN
-dN
-dN
-DW
+ys
+Pq
+vI
+rx
+fB
+Pq
+Pq
+Pq
+SB
+pp
 Ig
-DW
-dh
-dh
-dh
-dh
-DW
 Ig
-DW
-dh
-dh
+pp
+pp
+dN
+dN
+dN
+dN
+dN
+dN
+dN
+dN
 dN
 dN
 dN
@@ -51057,20 +51274,20 @@ Uf
 IB
 ey
 ys
-ys
-ys
-ys
-ys
-BF
-SV
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+ft
+vD
+Ul
+jP
+Ul
+zp
+Ab
+oa
+eW
+wo
+wo
+wo
+wo
+Ig
 dN
 dN
 dN
@@ -51319,15 +51536,15 @@ Pq
 ly
 iO
 ms
-SV
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+Pq
+Pq
+Pq
+ZQ
+pp
+pp
+pp
+Ca
+Ig
 dN
 dN
 dN
@@ -51572,19 +51789,19 @@ IB
 eI
 fH
 rz
-ys
-ys
-ys
-BF
+Pq
+Pq
+Pq
+Pq
+Pq
+OG
+PK
+UV
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+Ig
+Ca
+pp
 dN
 dN
 dN
@@ -51831,18 +52048,18 @@ YN
 Bn
 Bn
 Bn
+qa
 ys
-ys
+pj
+BF
 dN
 dN
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
+Ig
+Ca
+pp
+vO
 dN
 dN
 dN
@@ -52096,9 +52313,9 @@ dN
 dN
 dN
 dN
-dN
-dN
-dN
+pp
+wo
+pp
 dN
 dN
 dN
@@ -52337,7 +52554,7 @@ En
 Xk
 Fj
 AE
-qP
+Vi
 qP
 qP
 Dz
@@ -52354,8 +52571,8 @@ Hy
 Hy
 pp
 if
-dN
-dN
+Ca
+pp
 dN
 dN
 dN
@@ -52599,7 +52816,7 @@ qP
 ty
 HB
 HB
-wQ
+TP
 CQ
 Gs
 ST
@@ -52611,20 +52828,20 @@ eO
 Hy
 dN
 DW
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+Ca
+pp
+DW
+Ig
+DW
+DW
+dh
+dh
+dh
+DW
+Ig
+DW
+dh
+dh
 dN
 dN
 dN
@@ -52868,21 +53085,21 @@ Pf
 Hy
 dN
 DW
+Ca
+pp
+dN
+pp
 dN
 dN
 dN
 dN
 dN
 dN
+pp
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+dh
+dh
 dN
 dN
 dN
@@ -53125,21 +53342,21 @@ Hy
 Hy
 pp
 Ig
+wo
+pp
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+dh
 dN
 dN
 dN
@@ -53382,21 +53599,21 @@ WU
 Hy
 dN
 DW
+Ca
+pp
 dN
-dN
-vO
-dN
-dN
-dN
-dN
+Gu
 dN
 dN
 dN
 dN
 dN
 dN
+Gu
 dN
 dN
+dN
+dh
 dN
 dN
 dN
@@ -53639,21 +53856,21 @@ Sc
 Hy
 dN
 DW
+Ca
+pp
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+dh
 dN
 dN
 dN
@@ -53896,21 +54113,21 @@ Hy
 Hy
 pp
 if
+Ca
+pp
+pp
+GC
+pp
+pp
+pp
+pp
+pp
+pp
+NZ
+pp
+pp
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+DW
 dN
 dN
 dN
@@ -54153,21 +54370,21 @@ kQ
 Hy
 dN
 DW
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+wo
+wo
+wo
+pj
+pj
+pj
+pj
+pj
+pj
+pj
+So
+wo
+Eh
+pp
+Ig
 dN
 dN
 dN
@@ -54410,21 +54627,21 @@ oi
 Hy
 dN
 DW
+Ig
+pp
+pp
+NZ
+pp
+pp
+uz
+pp
+pp
+pp
+NZ
+pp
+pp
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+DW
 dN
 dN
 dN
@@ -54669,19 +54886,19 @@ pp
 if
 dN
 dN
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+dh
 dN
 dN
 dN
@@ -54899,11 +55116,11 @@ cK
 fz
 NH
 bH
-zZ
+BG
 JL
-jt
-zZ
-zZ
+Nb
+BG
+LF
 NH
 zv
 GL
@@ -54927,18 +55144,18 @@ DW
 dN
 dN
 dN
+Gu
 dN
 dN
 dN
 dN
 dN
 dN
+Gu
 dN
 dN
 dN
-dN
-dN
-dN
+DW
 dN
 dN
 dN
@@ -55181,21 +55398,21 @@ Ta
 Hy
 dN
 DW
+Pa
+Pa
+in
+wo
+in
+in
+in
+in
+in
+in
+wo
+in
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+dh
 dN
 dN
 dN
@@ -55441,18 +55658,18 @@ if
 dN
 dN
 dN
+pp
 dN
 dN
 dN
 dN
 dN
 dN
+pp
 dN
 dN
-dN
-dN
-dN
-dN
+dh
+dh
 dN
 dN
 dN
@@ -55697,18 +55914,18 @@ dN
 DW
 dN
 dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
+DW
+Ig
+DW
+dh
+dh
+dh
+dh
+DW
+Ig
+DW
+dh
+dh
 dN
 dN
 dN
@@ -56211,7 +56428,7 @@ DW
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -56705,10 +56922,10 @@ CP
 CP
 LP
 Ok
-LA
+Fk
 CP
 CP
-CP
+ji
 ys
 lj
 ys
@@ -56962,8 +57179,8 @@ Dc
 LP
 LP
 Uv
-Fk
-CP
+DC
+CA
 xj
 Kw
 pI
@@ -57753,7 +57970,7 @@ dN
 dN
 dN
 dN
-vO
+dN
 dN
 dN
 dN
@@ -64926,7 +65143,7 @@ dN
 dN
 FP
 Ki
-Am
+nD
 fZ
 Bc
 qk
@@ -65440,8 +65657,8 @@ dN
 dN
 FP
 fl
-fa
-fa
+io
+Zr
 sl
 FP
 Xv
@@ -65698,7 +65915,7 @@ dN
 oH
 ih
 fa
-fa
+Zr
 rq
 FP
 Bs
@@ -66212,7 +66429,7 @@ pp
 oH
 FP
 oH
-oH
+jA
 FP
 oH
 FP
@@ -66469,7 +66686,7 @@ Mi
 Mi
 pp
 Mi
-Mi
+kz
 pp
 FP
 FP

--- a/_maps/map_files/Freebooter/Freebooter.dmm
+++ b/_maps/map_files/Freebooter/Freebooter.dmm
@@ -224,6 +224,10 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
+"aS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port)
 "aT" = (
 /obj/structure/railing{
 	dir = 1
@@ -358,6 +362,10 @@
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/wood/large,
 /area/ruin/powered)
+"br" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "bt" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm/directional/west,
@@ -499,6 +507,12 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"bT" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "bU" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/disposalpipe/segment{
@@ -571,6 +585,10 @@
 /obj/item/dice/d20/fate/stealth/one_use,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"cl" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "cm" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/machinery/light/nightshift/directional/east,
@@ -1024,6 +1042,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/closed/wall,
 /area/station/maintenance/department/engine/atmos)
+"dP" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/tcommsat/computer)
 "dQ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
@@ -1340,6 +1362,17 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical)
+"fd" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "ff" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -1404,10 +1437,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical)
-"fo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port)
 "fp" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -1433,11 +1462,9 @@
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "ft" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/plating/airless,
+/area/space/nearstation/nostarlight)
 "fu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -1492,13 +1519,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/research/abandoned)
 "fB" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
+/obj/item/stack/cable_coil,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fC" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 4
@@ -1637,6 +1661,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"fX" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "fY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
@@ -1693,6 +1723,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"gh" = (
+/obj/item/wirecutters,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -2289,11 +2324,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"io" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/research/abandoned)
 "ip" = (
 /obj/machinery/computer/operating,
 /obj/machinery/airalarm/directional/north,
@@ -2391,6 +2421,12 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/fore)
+"iK" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "iL" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -2417,6 +2453,7 @@
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/random/directional/east,
+/obj/machinery/light/emergency/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard)
 "iQ" = (
@@ -2514,10 +2551,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "ji" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/fire/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research/abandoned)
 "jj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
@@ -2548,6 +2585,13 @@
 /obj/structure/sign/warning/explosives/alt/directional/north,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"jo" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "jp" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2609,10 +2653,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"jA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/science/research/abandoned)
 "jB" = (
 /obj/machinery/ai_slipper,
 /turf/open/floor/engine,
@@ -2691,11 +2731,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
-"jP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "jQ" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -2890,12 +2925,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kz" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/railing/corner,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "kA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -3020,10 +3052,14 @@
 /obj/item/pen/screwdriver,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
-"la" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
+"kZ" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "lb" = (
 /obj/vehicle/ridden/scooter,
 /obj/effect/decal/cleanable/blood/old,
@@ -3492,14 +3528,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/fitness)
-"mI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "mJ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -3560,6 +3588,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/commons/dorms)
+"mY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "na" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/miner/plasma,
@@ -3721,10 +3756,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "nD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/research/abandoned)
+/obj/item/stack/rods/two,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/directional/south,
@@ -3843,18 +3878,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
-"oa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "ob" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4257,6 +4280,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
+"pA" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "pB" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/cryo_cell,
@@ -4406,10 +4435,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/storage)
-"qa" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "qb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -4529,6 +4554,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
+"qr" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "qs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -4864,18 +4895,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/smooth_half,
 /area/awaymission/secret/powered)
-"rx" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/light/emergency/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "ry" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
@@ -5271,6 +5290,14 @@
 /obj/machinery/suit_storage_unit/starsuit,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
+"ti" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "o2 pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "tj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -5501,11 +5528,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
-"ue" = (
-/obj/item/stack/rods/two,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "uf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5614,11 +5636,6 @@
 	},
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
-"uz" = (
-/obj/item/stack/cable_coil,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "uA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5638,6 +5655,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
+"uD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "uF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/dresser,
@@ -5933,13 +5955,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vD" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
+/turf/closed/wall/r_wall,
+/area/station/science/research/abandoned)
 "vE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -5953,12 +5971,6 @@
 	},
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"vI" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "vJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
@@ -6872,10 +6884,6 @@
 "zp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
@@ -7072,12 +7080,6 @@
 /obj/structure/closet/secure_closet/medsci_spec,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
-"Ab" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -7517,10 +7519,6 @@
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"BG" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
 "BH" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured_large,
@@ -7624,11 +7622,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering)
-"Ca" = (
-/obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Cb" = (
 /obj/effect/decal/cleanable/robot_debris/up,
 /turf/open/floor/circuit/airless,
@@ -7768,13 +7761,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
-"CA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "CC" = (
 /obj/machinery/conveyor/inverted{
 	id = "garbage";
@@ -7910,17 +7896,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "CZ" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/structure/railing,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"Da" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/department/crew_quarters/dorms)
 "Db" = (
 /obj/machinery/computer/operating,
 /obj/machinery/newscaster/directional/north,
@@ -8052,6 +8031,11 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"DA" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/hydroponics/garden)
 "DB" = (
 /obj/structure/cable,
 /obj/structure/closet/emcloset/wall{
@@ -8062,13 +8046,6 @@
 	},
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/bridge)
-"DC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "DD" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -8594,11 +8571,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
-"Fu" = (
-/obj/item/wirecutters,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "Fx" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plating,
@@ -8891,8 +8863,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "GC" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "GD" = (
 /turf/open/floor/iron/dark/textured_large,
@@ -8990,6 +8963,18 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/station/service/kitchen)
+"GV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "GW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm/directional/south,
@@ -9289,6 +9274,10 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/fore)
+"Id" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "Ie" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10018,6 +10007,14 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/fore)
+"KK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "KL" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/stone,
@@ -10245,18 +10242,9 @@
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "LA" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
-"LB" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/window/spawner/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/service/hydroponics/garden)
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "LC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10272,12 +10260,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
-"LF" = (
-/obj/machinery/telecomms/message_server/preset,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
 "LG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
@@ -10384,6 +10366,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
+"LZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "Ma" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
@@ -10708,10 +10697,6 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
-"Nb" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/tcommsat/computer)
 "Nc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -10758,6 +10743,11 @@
 "Nj" = (
 /obj/structure/cable,
 /obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
+"Nk" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "Nn" = (
@@ -10921,6 +10911,10 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
+"NO" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "NP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
@@ -11120,10 +11114,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
-"OG" = (
-/obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "OI" = (
 /obj/item/kirbyplants,
 /turf/open/floor/wood/large,
@@ -11365,6 +11355,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"PC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "PD" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark/textured,
@@ -11491,6 +11486,14 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
+"Qf" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Qg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11629,6 +11632,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
+"QJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "QK" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
@@ -11663,6 +11672,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"QT" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "QU" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -12017,10 +12034,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
-"So" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Sp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12070,13 +12083,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"SB" = (
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "SC" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -12218,6 +12224,13 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/space/basic,
+/area/space/nearstation)
+"SW" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
 /turf/open/space/basic,
 /area/space/nearstation)
 "SX" = (
@@ -12424,13 +12437,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "TP" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "o2 pump"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "TQ" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -12560,12 +12570,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"Ul" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "Um" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12593,6 +12597,14 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"Ut" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12620,6 +12632,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port)
+"Uy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12649,6 +12671,7 @@
 /obj/item/card/id/advanced/gold/captains_spare,
 /obj/item/storage/belt/sabre,
 /obj/item/pinpointer/nuke,
+/obj/item/research_notes/p10000,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/nuke_storage)
 "UI" = (
@@ -12712,12 +12735,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"UV" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "UW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/textured_large,
@@ -12781,12 +12798,6 @@
 "Vh" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
-"Vi" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "Vj" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -13036,11 +13047,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/science)
-"Wf" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Wg" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/power/solar_control{
@@ -13934,11 +13940,6 @@
 /obj/item/knife/combat/survival,
 /turf/open/misc/asteroid/airless,
 /area/ruin/powered)
-"Zn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Zp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/north,
@@ -13950,10 +13951,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"Zr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/research/abandoned)
 "Zt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14129,6 +14126,10 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"ZV" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/department/crew_quarters/dorms)
 "ZW" = (
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
@@ -43831,12 +43832,12 @@ xJ
 RS
 wB
 Gj
-Da
+ZV
 mt
 mt
 RC
 nt
-la
+Id
 nt
 dN
 dN
@@ -44825,7 +44826,7 @@ An
 PW
 PW
 PW
-LB
+DA
 GW
 we
 cN
@@ -44853,9 +44854,9 @@ iM
 rM
 Wg
 YH
-fo
+aS
 YH
-mI
+KK
 dN
 dN
 dN
@@ -47168,7 +47169,7 @@ Mi
 Mi
 Mi
 eW
-ue
+nD
 dN
 in
 wo
@@ -47426,16 +47427,16 @@ dN
 pp
 eW
 pp
-uz
+fB
 pp
-GC
-pp
-pp
-pp
-ue
+ft
 pp
 pp
-GC
+pp
+nD
+pp
+pp
+ft
 pp
 pp
 dN
@@ -47694,7 +47695,7 @@ NZ
 wo
 wo
 wo
-Wf
+Nk
 tP
 Ig
 dN
@@ -47939,7 +47940,7 @@ dN
 dN
 pp
 SV
-Fu
+gh
 pp
 pp
 NZ
@@ -50766,9 +50767,9 @@ Pq
 Pq
 Pq
 Pq
-Zn
-LA
-CZ
+GC
+Qf
+Ut
 dN
 dN
 dN
@@ -51019,13 +51020,13 @@ ym
 ys
 ys
 Pq
-vI
-rx
-fB
+bT
+fd
+QT
 Pq
 Pq
 Pq
-SB
+jo
 pp
 Ig
 Ig
@@ -51274,14 +51275,14 @@ Uf
 IB
 ey
 ys
-ft
-vD
-Ul
-jP
-Ul
+QJ
+kZ
+pA
+uD
+pA
+Uy
 zp
-Ab
-oa
+GV
 eW
 wo
 wo
@@ -51543,7 +51544,7 @@ ZQ
 pp
 pp
 pp
-Ca
+CZ
 Ig
 dN
 dN
@@ -51794,13 +51795,13 @@ Pq
 Pq
 Pq
 Pq
-OG
+kz
 PK
-UV
+qr
 dN
 dN
 Ig
-Ca
+CZ
 pp
 dN
 dN
@@ -52048,7 +52049,7 @@ YN
 Bn
 Bn
 Bn
-qa
+NO
 ys
 pj
 BF
@@ -52057,7 +52058,7 @@ dN
 dN
 dN
 Ig
-Ca
+CZ
 pp
 vO
 dN
@@ -52554,7 +52555,7 @@ En
 Xk
 Fj
 AE
-Vi
+iK
 qP
 qP
 Dz
@@ -52571,7 +52572,7 @@ Hy
 Hy
 pp
 if
-Ca
+CZ
 pp
 dN
 dN
@@ -52816,7 +52817,7 @@ qP
 ty
 HB
 HB
-TP
+ti
 CQ
 Gs
 ST
@@ -52828,7 +52829,7 @@ eO
 Hy
 dN
 DW
-Ca
+CZ
 pp
 DW
 Ig
@@ -53085,7 +53086,7 @@ Pf
 Hy
 dN
 DW
-Ca
+CZ
 pp
 dN
 pp
@@ -53599,7 +53600,7 @@ WU
 Hy
 dN
 DW
-Ca
+CZ
 pp
 dN
 Gu
@@ -53856,7 +53857,7 @@ Sc
 Hy
 dN
 DW
-Ca
+CZ
 pp
 in
 wo
@@ -54113,10 +54114,10 @@ Hy
 Hy
 pp
 if
-Ca
+CZ
 pp
 pp
-GC
+ft
 pp
 pp
 pp
@@ -54380,7 +54381,7 @@ pj
 pj
 pj
 pj
-So
+cl
 wo
 Eh
 pp
@@ -54633,7 +54634,7 @@ pp
 NZ
 pp
 pp
-uz
+fB
 pp
 pp
 pp
@@ -55116,11 +55117,11 @@ cK
 fz
 NH
 bH
-BG
+br
 JL
-Nb
-BG
-LF
+dP
+br
+fX
 NH
 zv
 GL
@@ -56925,7 +56926,7 @@ Ok
 Fk
 CP
 CP
-ji
+PC
 ys
 lj
 ys
@@ -57179,8 +57180,8 @@ Dc
 LP
 LP
 Uv
-DC
-CA
+mY
+LZ
 xj
 Kw
 pI
@@ -65143,7 +65144,7 @@ dN
 dN
 FP
 Ki
-nD
+ji
 fZ
 Bc
 qk
@@ -65657,8 +65658,8 @@ dN
 dN
 FP
 fl
-io
-Zr
+TP
+LA
 sl
 FP
 Xv
@@ -65915,7 +65916,7 @@ dN
 oH
 ih
 fa
-Zr
+LA
 rq
 FP
 Bs
@@ -66429,7 +66430,7 @@ pp
 oH
 FP
 oH
-jA
+vD
 FP
 oH
 FP
@@ -66686,7 +66687,7 @@ Mi
 Mi
 pp
 Mi
-kz
+SW
 pp
 FP
 FP

--- a/_maps/map_files/Freebooter/Freebooter.dmm
+++ b/_maps/map_files/Freebooter/Freebooter.dmm
@@ -42,19 +42,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/commons/dorms)
-"ai" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/research/abandoned)
-"aj" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "ak" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
@@ -179,10 +166,6 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical)
-"aF" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/department/crew_quarters/dorms)
 "aG" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood,
@@ -241,12 +224,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
-"aR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "aT" = (
 /obj/structure/railing{
 	dir = 1
@@ -329,6 +306,18 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"bg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "bh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -381,6 +370,13 @@
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/wood/large,
 /area/ruin/powered)
+"bs" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "bt" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm/directional/west,
@@ -523,10 +519,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"bT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/research/abandoned)
 "bU" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/disposalpipe/segment{
@@ -580,6 +572,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research/abandoned)
+"cf" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "cg" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -599,12 +599,10 @@
 /obj/item/dice/d20/fate/stealth/one_use,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"ck" = (
-/obj/machinery/telecomms/message_server/preset,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
+"cl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port)
 "cm" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/machinery/light/nightshift/directional/east,
@@ -794,12 +792,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/fore)
-"cT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "cU" = (
 /obj/structure/sign/directions/evac/directional/south{
 	pixel_y = -40
@@ -1057,14 +1049,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"dM" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "dN" = (
 /turf/open/space/basic,
 /area/space)
@@ -1370,6 +1354,12 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"eY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "eZ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Chief Engineer's Office"
@@ -1477,10 +1467,9 @@
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "ft" = (
-/obj/item/stack/cable_coil,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "fu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -1535,11 +1524,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/research/abandoned)
 "fB" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "fC" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 4
@@ -1623,14 +1613,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
-"fP" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "fQ" = (
 /obj/machinery/stasis{
 	dir = 4
@@ -1808,14 +1790,6 @@
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
-"gt" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "gu" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -2047,11 +2021,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/security/range)
-"hn" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/window/spawner/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/service/hydroponics/garden)
 "ho" = (
 /obj/structure/mecha_wreckage/ripley,
 /turf/open/misc/asteroid/airless,
@@ -2247,10 +2216,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
-"hS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
 "hT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2576,12 +2541,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "ji" = (
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+/obj/item/wirecutters,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
@@ -2612,14 +2575,6 @@
 /obj/structure/sign/warning/explosives/alt/directional/north,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"jo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "jp" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -2860,11 +2815,6 @@
 	},
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"kg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "ki" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -3115,6 +3065,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"lh" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "li" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -3769,15 +3727,21 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science)
+"nB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "nC" = (
 /obj/machinery/light/nightshift/directional/west,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "nD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port)
+/obj/item/stack/cable_coil,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "nE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/directional/south,
@@ -4152,6 +4116,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
+"pa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "pb" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access = list("maint_tunnels")
@@ -4613,6 +4581,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/library/lounge)
+"qC" = (
+/obj/structure/railing/corner,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "qD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4766,10 +4738,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
-"qZ" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
 "ra" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -4901,6 +4869,10 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/hallway/primary/aft)
+"rv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/science/research/abandoned)
 "rw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/smooth_half,
@@ -5121,6 +5093,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/service/chapel)
+"su" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "sw" = (
 /obj/item/clothing/head/soft/red,
 /turf/open/misc/asteroid/airless,
@@ -5175,10 +5151,6 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/airless,
 /area/ruin/powered)
-"sH" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "sI" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/random/double,
@@ -5898,6 +5870,10 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"vt" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "vu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "dormwindow2"
@@ -5956,11 +5932,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vD" = (
-/obj/structure/railing{
-	dir = 6
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
 	},
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+/turf/open/space/basic,
+/area/space/nearstation)
 "vE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -5968,6 +5945,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical)
+"vF" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "o2 pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "vG" = (
 /obj/structure/railing{
 	dir = 0
@@ -5988,6 +5973,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/range)
+"vL" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/hydroponics/garden)
 "vM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6023,6 +6013,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
+"vW" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "vX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6055,10 +6056,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
-"wb" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/plating/airless,
-/area/space/nearstation/nostarlight)
 "wc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -6278,7 +6275,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "o2 pump"
+	name = "n2 pump"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -6472,10 +6469,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/station/medical)
-"xH" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "xI" = (
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -6536,11 +6529,6 @@
 /area/station/service/kitchen)
 "xX" = (
 /turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation)
-"xY" = (
-/obj/item/wirecutters,
-/obj/structure/lattice,
-/turf/open/space/basic,
 /area/space/nearstation)
 "xZ" = (
 /obj/machinery/shower/directional/south,
@@ -6898,17 +6886,11 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/ce)
 "zp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
+/area/station/maintenance/department/engine/atmos)
 "zq" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -7055,11 +7037,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
-"zS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/research/abandoned)
 "zT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
@@ -7107,6 +7084,16 @@
 /obj/structure/closet/secure_closet/medsci_spec,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
+"Ab" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -7252,13 +7239,6 @@
 /obj/structure/bed,
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
-"AG" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "AH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -7708,10 +7688,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/fitness)
-"Cl" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/tcommsat/computer)
 "Cm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -7934,8 +7910,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "CZ" = (
-/obj/structure/cable,
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "Db" = (
@@ -8611,6 +8590,11 @@
 "Fy" = (
 /turf/closed/wall/mineral/iron,
 /area/ruin/powered)
+"Fz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research/abandoned)
 "FA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8779,6 +8763,12 @@
 /obj/item/clothing/under/misc/pj/red,
 /turf/open/floor/wood/large,
 /area/ruin/powered)
+"Gh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "Gj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
@@ -8896,11 +8886,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "GC" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "GD" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
@@ -9259,6 +9248,11 @@
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/smooth_half,
 /area/awaymission/secret/powered)
+"HS" = (
+/obj/item/stack/rods/two,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "HU" = (
 /obj/structure/window/spawner,
 /obj/machinery/portable_atmospherics/pump,
@@ -9557,11 +9551,14 @@
 /obj/item/target,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/range)
-"IT" = (
-/obj/item/stack/rods/two,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+"IV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "IW" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -9602,13 +9599,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science)
-"Jc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "Jd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9841,6 +9831,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
+"JW" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "JX" = (
 /obj/item/stack/cable_coil/one,
 /turf/open/misc/asteroid/airless,
@@ -9878,6 +9874,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/bridge)
+"Kf" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/tcommsat/computer)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9930,10 +9930,6 @@
 /obj/effect/landmark/start/scoundrel/deckhand,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
-"Kr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/science/research/abandoned)
 "Ks" = (
 /obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
@@ -10268,13 +10264,10 @@
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "LA" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "n2 pump"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "LC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10720,6 +10713,10 @@
 /obj/structure/noticeboard/directional/east,
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
+"Na" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/plating/airless,
+/area/space/nearstation/nostarlight)
 "Nc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -11018,6 +11015,10 @@
 /obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/engine,
 /area/station/ai_monitored/aisat)
+"Oi" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/department/crew_quarters/dorms)
 "Oj" = (
 /obj/structure/rack,
 /obj/item/construction/rcd/loaded,
@@ -11033,12 +11034,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"Ol" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "On" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11134,10 +11129,6 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
-"OH" = (
-/obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "OI" = (
 /obj/item/kirbyplants,
 /turf/open/floor/wood/large,
@@ -12043,6 +12034,13 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/lobby)
+"Sr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "St" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
@@ -12080,6 +12078,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"Sz" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "SC" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -12299,6 +12303,14 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/hydroponics/garden)
+"To" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Tq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12427,14 +12439,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "TP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/starboard)
 "TQ" = (
 /obj/structure/table/wood,
@@ -12494,11 +12502,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
-"TZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Ua" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/mech_bay_recharge_port{
@@ -12624,6 +12627,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port)
+"Uy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12872,9 +12880,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"VA" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "VB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
+"VC" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "VD" = (
@@ -13406,17 +13424,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/bar)
-"Xq" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "Xr" = (
 /obj/structure/fans/tiny,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13434,10 +13441,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/awaymission/secret/powered)
 "Xs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/fire/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Xt" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/tile/green{
@@ -13644,13 +13651,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
-"Ye" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "Yg" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
@@ -43833,12 +43833,12 @@ xJ
 RS
 wB
 Gj
-aF
+Oi
 mt
 mt
 RC
 nt
-hS
+pa
 nt
 dN
 dN
@@ -44827,7 +44827,7 @@ An
 PW
 PW
 PW
-hn
+vL
 GW
 we
 cN
@@ -44855,9 +44855,9 @@ iM
 rM
 Wg
 YH
-nD
+cl
 YH
-jo
+IV
 dN
 dN
 dN
@@ -47170,7 +47170,7 @@ Mi
 Mi
 Mi
 eW
-IT
+HS
 dN
 in
 wo
@@ -47428,16 +47428,16 @@ dN
 pp
 eW
 pp
-ft
+nD
 pp
-wb
-pp
-pp
-pp
-IT
+Na
 pp
 pp
-wb
+pp
+HS
+pp
+pp
+Na
 pp
 pp
 dN
@@ -47941,7 +47941,7 @@ dN
 dN
 pp
 SV
-xY
+ji
 pp
 pp
 NZ
@@ -50768,9 +50768,9 @@ Pq
 Pq
 Pq
 Pq
-TZ
-dM
-gt
+Xs
+To
+CZ
 dN
 dN
 dN
@@ -51021,13 +51021,13 @@ ym
 ys
 ys
 Pq
-fB
-Xq
-aj
+TP
+vW
+cf
 Pq
 Pq
 Pq
-ji
+bs
 pp
 Ig
 Ig
@@ -51044,7 +51044,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -51276,14 +51276,14 @@ Uf
 IB
 ey
 ys
-cT
-fP
-Ol
-kg
-Ol
-TP
-aR
 zp
+lh
+Gh
+Uy
+Gh
+Ab
+eY
+bg
 eW
 wo
 wo
@@ -51545,7 +51545,7 @@ ZQ
 pp
 pp
 pp
-CZ
+LA
 Ig
 dN
 dN
@@ -51796,13 +51796,13 @@ Pq
 Pq
 Pq
 Pq
-OH
+qC
 PK
-vD
+JW
 dN
 dN
 Ig
-CZ
+LA
 pp
 dN
 dN
@@ -52050,7 +52050,7 @@ YN
 Bn
 Bn
 Bn
-xH
+su
 ys
 pj
 BF
@@ -52059,9 +52059,9 @@ dN
 dN
 dN
 Ig
-CZ
+LA
 pp
-vO
+dN
 dN
 dN
 dN
@@ -52556,7 +52556,7 @@ En
 Xk
 Fj
 AE
-GC
+VC
 qP
 qP
 Dz
@@ -52573,7 +52573,7 @@ Hy
 Hy
 pp
 if
-CZ
+LA
 pp
 dN
 dN
@@ -52818,7 +52818,7 @@ qP
 ty
 HB
 HB
-wQ
+vF
 CQ
 Gs
 ST
@@ -52830,7 +52830,7 @@ eO
 Hy
 dN
 DW
-CZ
+LA
 pp
 DW
 Ig
@@ -53087,7 +53087,7 @@ Pf
 Hy
 dN
 DW
-CZ
+LA
 pp
 dN
 pp
@@ -53332,7 +53332,7 @@ YF
 dW
 dW
 dW
-LA
+wQ
 ix
 Hr
 tX
@@ -53601,7 +53601,7 @@ WU
 Hy
 dN
 DW
-CZ
+LA
 pp
 dN
 Gu
@@ -53858,7 +53858,7 @@ Sc
 Hy
 dN
 DW
-CZ
+LA
 pp
 in
 wo
@@ -54115,10 +54115,10 @@ Hy
 Hy
 pp
 if
-CZ
+LA
 pp
 pp
-wb
+Na
 pp
 pp
 pp
@@ -54382,7 +54382,7 @@ pj
 pj
 pj
 pj
-sH
+vt
 wo
 Eh
 pp
@@ -54635,7 +54635,7 @@ pp
 NZ
 pp
 pp
-ft
+nD
 pp
 pp
 pp
@@ -55118,11 +55118,11 @@ cK
 fz
 NH
 bH
-qZ
+VA
 JL
-Cl
-qZ
-ck
+Kf
+VA
+Sz
 NH
 zv
 GL
@@ -56430,7 +56430,7 @@ DW
 dN
 dN
 dN
-vO
+dN
 dN
 dN
 dN
@@ -56927,7 +56927,7 @@ Ok
 Fk
 CP
 CP
-Xs
+GC
 ys
 lj
 ys
@@ -57181,8 +57181,8 @@ Dc
 LP
 LP
 Uv
-Jc
-Ye
+fB
+Sr
 xj
 Kw
 pI
@@ -58246,7 +58246,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -60282,7 +60282,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -63595,7 +63595,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -65145,7 +65145,7 @@ dN
 dN
 FP
 Ki
-ai
+Fz
 fZ
 Bc
 qk
@@ -65659,8 +65659,8 @@ dN
 dN
 FP
 fl
-zS
-bT
+nB
+ft
 sl
 FP
 Xv
@@ -65917,7 +65917,7 @@ dN
 oH
 ih
 fa
-bT
+ft
 rq
 FP
 Bs
@@ -66197,7 +66197,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -66431,7 +66431,7 @@ pp
 oH
 FP
 oH
-Kr
+rv
 FP
 oH
 FP
@@ -66688,7 +66688,7 @@ Mi
 Mi
 pp
 Mi
-AG
+vD
 pp
 FP
 FP
@@ -68218,7 +68218,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN
@@ -69792,7 +69792,7 @@ dN
 dN
 dN
 dN
-dN
+vO
 dN
 dN
 dN

--- a/_maps/map_files/Freebooter/Freebooter.dmm
+++ b/_maps/map_files/Freebooter/Freebooter.dmm
@@ -306,18 +306,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"bg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "bh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -370,13 +358,6 @@
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/wood/large,
 /area/ruin/powered)
-"bs" = (
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "bt" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm/directional/west,
@@ -458,6 +439,12 @@
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/computer)
+"bI" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -572,14 +559,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research/abandoned)
-"cf" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "cg" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -599,10 +578,6 @@
 /obj/item/dice/d20/fate/stealth/one_use,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"cl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port)
 "cm" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/machinery/light/nightshift/directional/east,
@@ -1064,6 +1039,14 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
+"dS" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "dT" = (
 /obj/item/ammo_casing/spent,
 /obj/structure/lattice,
@@ -1354,12 +1337,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"eY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "eZ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Chief Engineer's Office"
@@ -1442,6 +1419,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical)
+"fo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "fp" = (
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 8
@@ -1467,9 +1449,12 @@
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "ft" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/station/science/research/abandoned)
+/area/station/maintenance/disposal/incinerator)
 "fu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -1525,11 +1510,9 @@
 /area/station/science/research/abandoned)
 "fB" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/power/solar,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "fC" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 4
@@ -1613,6 +1596,10 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
+"fP" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "fQ" = (
 /obj/machinery/stasis{
 	dir = 4
@@ -1742,6 +1729,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
+"gk" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "gl" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/welding,
@@ -1790,6 +1781,13 @@
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
+"gt" = (
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "gu" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -2541,10 +2539,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "ji" = (
-/obj/item/wirecutters,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "jj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
@@ -2908,8 +2908,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/power/solar,
+/obj/structure/railing,
+/obj/structure/marker_beacon/burgundy,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "kA" = (
@@ -3065,14 +3068,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"lh" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "li" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -3342,6 +3337,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"md" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "me" = (
 /obj/machinery/airalarm/directional/west,
 /obj/item/radio/intercom/directional/south,
@@ -3572,6 +3579,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/commons/dorms)
+"mZ" = (
+/obj/structure/railing/corner,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "na" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/miner/plasma,
@@ -3727,21 +3738,15 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/science)
-"nB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/research/abandoned)
 "nC" = (
 /obj/machinery/light/nightshift/directional/west,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "nD" = (
-/obj/item/stack/cable_coil,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/science/research/abandoned)
 "nE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/directional/south,
@@ -3850,6 +3855,10 @@
 	},
 /turf/closed/wall,
 /area/station/service/hydroponics/garden)
+"nY" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/tcommsat/computer)
 "nZ" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty,
@@ -4116,10 +4125,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"pa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
 "pb" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access = list("maint_tunnels")
@@ -4581,10 +4586,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/library/lounge)
-"qC" = (
-/obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "qD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -4610,6 +4611,14 @@
 /obj/item/candle,
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
+"qH" = (
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "o2 pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4869,10 +4878,6 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/hallway/primary/aft)
-"rv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/science/research/abandoned)
 "rw" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/smooth_half,
@@ -4950,6 +4955,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/rd)
+"rQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "rR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -5093,10 +5103,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/service/chapel)
-"su" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "sw" = (
 /obj/item/clothing/head/soft/red,
 /turf/open/misc/asteroid/airless,
@@ -5396,6 +5402,12 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet/red,
 /area/station/service/library/lounge)
+"tG" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "tH" = (
 /obj/structure/sign/warning/pods/directional/east,
 /turf/open/floor/iron/dark/textured_large,
@@ -5744,6 +5756,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port)
+"uX" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "uY" = (
 /obj/machinery/mass_driver/ordnance{
 	dir = 1
@@ -5870,10 +5888,6 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"vt" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "vu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "dormwindow2"
@@ -5932,12 +5946,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vD" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "vE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -5945,14 +5958,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical)
-"vF" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "o2 pump"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vG" = (
 /obj/structure/railing{
 	dir = 0
@@ -5973,11 +5978,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/range)
-"vL" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/window/spawner/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/service/hydroponics/garden)
 "vM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6013,17 +6013,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/dorms)
-"vW" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "vX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6558,6 +6547,11 @@
 "ye" = (
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/qm)
+"yf" = (
+/obj/item/stack/cable_coil,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "yg" = (
 /obj/structure/table/reinforced,
 /obj/item/pai_card,
@@ -6886,11 +6880,9 @@
 /turf/closed/wall,
 /area/station/command/heads_quarters/ce)
 "zp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
+/area/station/science/research/abandoned)
 "zq" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -6907,6 +6899,10 @@
 /obj/machinery/ore_silo,
 /turf/open/floor/engine,
 /area/station/ai_monitored/command/nuke_storage)
+"zt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "zu" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -7084,16 +7080,6 @@
 /obj/structure/closet/secure_closet/medsci_spec,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
-"Ab" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
@@ -7105,6 +7091,17 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary)
+"Ae" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
+"Af" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "Ag" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/autoname/directional/east,
@@ -7910,13 +7907,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "CZ" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/department/crew_quarters/dorms)
 "Db" = (
 /obj/machinery/computer/operating,
 /obj/machinery/newscaster/directional/north,
@@ -8591,10 +8584,9 @@
 /turf/closed/wall/mineral/iron,
 /area/ruin/powered)
 "Fz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/research/abandoned)
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "FA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -8763,12 +8755,6 @@
 /obj/item/clothing/under/misc/pj/red,
 /turf/open/floor/wood/large,
 /area/ruin/powered)
-"Gh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "Gj" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
@@ -8886,10 +8872,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "GC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/fire/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "GD" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
@@ -9147,6 +9136,11 @@
 "Hy" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"Hz" = (
+/obj/item/wirecutters,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "HA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9248,11 +9242,6 @@
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/iron/smooth_half,
 /area/awaymission/secret/powered)
-"HS" = (
-/obj/item/stack/rods/two,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "HU" = (
 /obj/structure/window/spawner,
 /obj/machinery/portable_atmospherics/pump,
@@ -9551,14 +9540,6 @@
 /obj/item/target,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/range)
-"IV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "IW" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -9793,6 +9774,14 @@
 "JN" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/lobby)
+"JO" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "JP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -9831,12 +9820,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
-"JW" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "JX" = (
 /obj/item/stack/cable_coil/one,
 /turf/open/misc/asteroid/airless,
@@ -9874,10 +9857,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/bridge)
-"Kf" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/tcommsat/computer)
 "Kg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9930,6 +9909,10 @@
 /obj/effect/landmark/start/scoundrel/deckhand,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
+"Kr" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/plating/airless,
+/area/space/nearstation/nostarlight)
 "Ks" = (
 /obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
@@ -10264,10 +10247,11 @@
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "LA" = (
-/obj/structure/cable,
-/obj/structure/railing,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "LC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10714,9 +10698,10 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "Na" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/plating/airless,
-/area/space/nearstation/nostarlight)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research/abandoned)
 "Nc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -11015,10 +11000,6 @@
 /obj/structure/window/reinforced/plasma/spawner/west,
 /turf/open/floor/engine,
 /area/station/ai_monitored/aisat)
-"Oi" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/department/crew_quarters/dorms)
 "Oj" = (
 /obj/structure/rack,
 /obj/item/construction/rcd/loaded,
@@ -11701,6 +11682,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
+"Rd" = (
+/obj/item/stack/rods/two,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "Rf" = (
 /obj/item/tank/internals/oxygen,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -12034,13 +12020,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/lobby)
-"Sr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "St" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating,
@@ -12078,12 +12057,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"Sz" = (
-/obj/machinery/telecomms/message_server/preset,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
 "SC" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -12303,14 +12276,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/hydroponics/garden)
-"To" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Tq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12439,11 +12404,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "TP" = (
-/obj/machinery/power/smes/engineering,
 /obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
+/obj/structure/railing,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "TQ" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -12627,11 +12591,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port)
-"Uy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12646,6 +12605,10 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
+"UD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port)
 "UE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -12688,6 +12651,11 @@
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
+"UM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "UN" = (
 /obj/machinery/computer/crew,
 /turf/open/floor/wood/large,
@@ -12725,6 +12693,17 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"UV" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "UW" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark/textured_large,
@@ -12881,18 +12860,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "VA" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
+/obj/machinery/hydroponics/constructable,
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/hydroponics/garden)
 "VB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"VC" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "VD" = (
@@ -13334,6 +13308,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"WY" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "WZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner{
@@ -13440,11 +13421,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/awaymission/secret/powered)
-"Xs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Xt" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/tile/green{
@@ -13669,6 +13645,14 @@
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
+"Yj" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Yk" = (
 /obj/effect/turf_decal/tile/dark_green/half/contrasted,
 /obj/structure/table/reinforced,
@@ -13794,6 +13778,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/item/research_notes/p5000,
 /turf/open/floor/carpet/black,
 /area/station/command/heads_quarters/rd)
 "YH" = (
@@ -13945,6 +13930,12 @@
 /obj/item/knife/combat/survival,
 /turf/open/misc/asteroid/airless,
 /area/ruin/powered)
+"Zm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "Zp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/north,
@@ -14131,6 +14122,16 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"ZV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/starboard)
 "ZW" = (
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
@@ -43833,12 +43834,12 @@ xJ
 RS
 wB
 Gj
-Oi
+CZ
 mt
 mt
 RC
 nt
-pa
+zt
 nt
 dN
 dN
@@ -44827,7 +44828,7 @@ An
 PW
 PW
 PW
-vL
+VA
 GW
 we
 cN
@@ -44855,9 +44856,9 @@ iM
 rM
 Wg
 YH
-cl
+UD
 YH
-IV
+kz
 dN
 dN
 dN
@@ -46658,16 +46659,16 @@ pp
 eW
 pp
 dN
-kz
+fB
 wo
-kz
-kz
-kz
-kz
-kz
-kz
+fB
+fB
+fB
+fB
+fB
+fB
 wo
-kz
+fB
 dN
 dN
 Ig
@@ -47170,7 +47171,7 @@ Mi
 Mi
 Mi
 eW
-HS
+Rd
 dN
 in
 wo
@@ -47428,16 +47429,16 @@ dN
 pp
 eW
 pp
-nD
+yf
 pp
-Na
-pp
-pp
-pp
-HS
+Kr
 pp
 pp
-Na
+pp
+Rd
+pp
+pp
+Kr
 pp
 pp
 dN
@@ -47941,7 +47942,7 @@ dN
 dN
 pp
 SV
-ji
+Hz
 pp
 pp
 NZ
@@ -50768,9 +50769,9 @@ Pq
 Pq
 Pq
 Pq
-Xs
-To
-CZ
+UM
+Yj
+JO
 dN
 dN
 dN
@@ -51021,13 +51022,13 @@ ym
 ys
 ys
 Pq
-TP
-vW
-cf
+bI
+UV
+GC
 Pq
 Pq
 Pq
-bs
+gt
 pp
 Ig
 Ig
@@ -51276,14 +51277,14 @@ Uf
 IB
 ey
 ys
-zp
-lh
-Gh
-Uy
-Gh
-Ab
-eY
-bg
+Zm
+dS
+vD
+Af
+vD
+ZV
+Ae
+md
 eW
 wo
 wo
@@ -51545,7 +51546,7 @@ ZQ
 pp
 pp
 pp
-LA
+TP
 Ig
 dN
 dN
@@ -51796,13 +51797,13 @@ Pq
 Pq
 Pq
 Pq
-qC
+mZ
 PK
-JW
+uX
 dN
 dN
 Ig
-LA
+TP
 pp
 dN
 dN
@@ -52050,7 +52051,7 @@ YN
 Bn
 Bn
 Bn
-su
+Fz
 ys
 pj
 BF
@@ -52059,7 +52060,7 @@ dN
 dN
 dN
 Ig
-LA
+TP
 pp
 dN
 dN
@@ -52556,7 +52557,7 @@ En
 Xk
 Fj
 AE
-VC
+LA
 qP
 qP
 Dz
@@ -52573,7 +52574,7 @@ Hy
 Hy
 pp
 if
-LA
+TP
 pp
 dN
 dN
@@ -52818,7 +52819,7 @@ qP
 ty
 HB
 HB
-vF
+qH
 CQ
 Gs
 ST
@@ -52830,7 +52831,7 @@ eO
 Hy
 dN
 DW
-LA
+TP
 pp
 DW
 Ig
@@ -53087,7 +53088,7 @@ Pf
 Hy
 dN
 DW
-LA
+TP
 pp
 dN
 pp
@@ -53601,7 +53602,7 @@ WU
 Hy
 dN
 DW
-LA
+TP
 pp
 dN
 Gu
@@ -53858,7 +53859,7 @@ Sc
 Hy
 dN
 DW
-LA
+TP
 pp
 in
 wo
@@ -54115,10 +54116,10 @@ Hy
 Hy
 pp
 if
-LA
+TP
 pp
 pp
-Na
+Kr
 pp
 pp
 pp
@@ -54382,7 +54383,7 @@ pj
 pj
 pj
 pj
-vt
+gk
 wo
 Eh
 pp
@@ -54635,7 +54636,7 @@ pp
 NZ
 pp
 pp
-nD
+yf
 pp
 pp
 pp
@@ -55118,11 +55119,11 @@ cK
 fz
 NH
 bH
-VA
+fP
 JL
-Kf
-VA
-Sz
+nY
+fP
+tG
 NH
 zv
 GL
@@ -56927,7 +56928,7 @@ Ok
 Fk
 CP
 CP
-GC
+fo
 ys
 lj
 ys
@@ -57181,8 +57182,8 @@ Dc
 LP
 LP
 Uv
-fB
-Sr
+ft
+ji
 xj
 Kw
 pI
@@ -65145,7 +65146,7 @@ dN
 dN
 FP
 Ki
-Fz
+Na
 fZ
 Bc
 qk
@@ -65659,8 +65660,8 @@ dN
 dN
 FP
 fl
-nB
-ft
+rQ
+zp
 sl
 FP
 Xv
@@ -65917,7 +65918,7 @@ dN
 oH
 ih
 fa
-ft
+zp
 rq
 FP
 Bs
@@ -66431,7 +66432,7 @@ pp
 oH
 FP
 oH
-rv
+nD
 FP
 oH
 FP
@@ -66688,7 +66689,7 @@ Mi
 Mi
 pp
 Mi
-vD
+WY
 pp
 FP
 FP

--- a/_maps/map_files/Freebooter/Freebooter.dmm
+++ b/_maps/map_files/Freebooter/Freebooter.dmm
@@ -42,6 +42,19 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/commons/dorms)
+"ai" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/science/research/abandoned)
+"aj" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "ak" = (
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/iron,
@@ -166,6 +179,10 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical)
+"aF" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/department/crew_quarters/dorms)
 "aG" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/siding/wood,
@@ -224,10 +241,12 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
-"aS" = (
-/obj/effect/spawner/structure/window/reinforced,
+"aR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/maintenance/solars/port)
+/area/station/maintenance/solars/starboard)
 "aT" = (
 /obj/structure/railing{
 	dir = 1
@@ -362,10 +381,6 @@
 /obj/structure/window/reinforced/tinted/fulltile,
 /turf/open/floor/wood/large,
 /area/ruin/powered)
-"br" = (
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
 "bt" = (
 /obj/machinery/chem_master,
 /obj/machinery/firealarm/directional/west,
@@ -442,7 +457,8 @@
 "bH" = (
 /obj/structure/cable,
 /obj/machinery/power/smes{
-	dir = 4
+	dir = 4;
+	input_level = 22000
 	},
 /turf/open/floor/circuit,
 /area/station/tcommsat/computer)
@@ -508,11 +524,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "bT" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
-/obj/machinery/airalarm/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "bU" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/disposalpipe/segment{
@@ -585,10 +599,12 @@
 /obj/item/dice/d20/fate/stealth/one_use,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"cl" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+"ck" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "cm" = (
 /obj/machinery/telecomms/processor/preset_one,
 /obj/machinery/light/nightshift/directional/east,
@@ -778,6 +794,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/fore)
+"cT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "cU" = (
 /obj/structure/sign/directions/evac/directional/south{
 	pixel_y = -40
@@ -817,8 +839,8 @@
 /turf/open/floor/iron,
 /area/station/engineering)
 "cZ" = (
+/obj/machinery/power/tracker,
 /obj/structure/cable,
-/obj/machinery/power/solar,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "da" = (
@@ -1035,6 +1057,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
+"dM" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "dN" = (
 /turf/open/space/basic,
 /area/space)
@@ -1042,10 +1072,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/closed/wall,
 /area/station/maintenance/department/engine/atmos)
-"dP" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/tcommsat/computer)
 "dQ" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/iron,
@@ -1362,17 +1388,6 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical)
-"fd" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "ff" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -1462,9 +1477,10 @@
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "ft" = (
-/obj/item/stack/cable_coil/one,
-/turf/open/floor/plating/airless,
-/area/space/nearstation/nostarlight)
+/obj/item/stack/cable_coil,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -1519,10 +1535,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/research/abandoned)
 "fB" = (
-/obj/item/stack/cable_coil,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "fC" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 4
@@ -1606,6 +1623,14 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
+"fP" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "fQ" = (
 /obj/machinery/stasis{
 	dir = 4
@@ -1661,12 +1686,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
-"fX" = (
-/obj/machinery/telecomms/message_server/preset,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/turf/open/floor/circuit,
-/area/station/tcommsat/computer)
 "fY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/rack,
@@ -1723,11 +1742,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"gh" = (
-/obj/item/wirecutters,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "gi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
@@ -1794,6 +1808,14 @@
 /obj/effect/turf_decal/tile/dark_blue/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
+"gt" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "gu" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -2025,6 +2047,11 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/security/range)
+"hn" = (
+/obj/machinery/hydroponics/constructable,
+/obj/structure/window/spawner/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/station/service/hydroponics/garden)
 "ho" = (
 /obj/structure/mecha_wreckage/ripley,
 /turf/open/misc/asteroid/airless,
@@ -2220,6 +2247,10 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
+"hS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "hT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2421,12 +2452,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/fore)
-"iK" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iL" = (
 /obj/structure/table,
 /obj/structure/cable,
@@ -2551,10 +2576,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "ji" = (
+/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/science/research/abandoned)
+/obj/structure/marker_beacon/burgundy,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "jj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/plating,
@@ -2586,9 +2613,10 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "jo" = (
-/obj/structure/railing,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/railing,
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
@@ -2832,6 +2860,11 @@
 	},
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
+"kg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "ki" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -2925,7 +2958,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "kz" = (
-/obj/structure/railing/corner,
+/obj/structure/cable,
+/obj/machinery/power/solar,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
 "kA" = (
@@ -3052,14 +3086,6 @@
 /obj/item/pen/screwdriver,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/ce)
-"kZ" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "lb" = (
 /obj/vehicle/ridden/scooter,
 /obj/effect/decal/cleanable/blood/old,
@@ -3588,13 +3614,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/commons/dorms)
-"mY" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "na" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/miner/plasma,
@@ -3756,10 +3775,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
 "nD" = (
-/obj/item/stack/rods/two,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port)
 "nE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/directional/south,
@@ -4280,12 +4298,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
-"pA" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "pB" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/cryo_cell,
@@ -4554,12 +4566,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
-"qr" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "qs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -4760,6 +4766,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/bridge)
+"qZ" = (
+/obj/structure/cable,
+/turf/open/floor/circuit,
+/area/station/tcommsat/computer)
 "ra" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5165,6 +5175,10 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/misc/asteroid/airless,
 /area/ruin/powered)
+"sH" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "sI" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/random/double,
@@ -5290,14 +5304,6 @@
 /obj/machinery/suit_storage_unit/starsuit,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/captain)
-"ti" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "o2 pump"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -5655,11 +5661,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary)
-"uD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "uF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/dresser,
@@ -5955,9 +5956,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/science/research/abandoned)
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "vE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -6052,6 +6055,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"wb" = (
+/obj/item/stack/cable_coil/one,
+/turf/open/floor/plating/airless,
+/area/space/nearstation/nostarlight)
 "wc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -6271,7 +6278,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
-	name = "n2 pump"
+	name = "o2 pump"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -6465,6 +6472,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/station/medical)
+"xH" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine/atmos)
 "xI" = (
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
@@ -6525,6 +6536,11 @@
 /area/station/service/kitchen)
 "xX" = (
 /turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation)
+"xY" = (
+/obj/item/wirecutters,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/space/nearstation)
 "xZ" = (
 /obj/machinery/shower/directional/south,
@@ -6884,6 +6900,12 @@
 "zp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard)
@@ -7033,6 +7055,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/rd)
+"zS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/science/research/abandoned)
 "zT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
@@ -7225,6 +7252,13 @@
 /obj/structure/bed,
 /turf/open/floor/wood/large,
 /area/station/service/chapel)
+"AG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "AH" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -7674,6 +7708,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/fitness)
+"Cl" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/tcommsat/computer)
 "Cm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8031,11 +8069,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"DA" = (
-/obj/machinery/hydroponics/constructable,
-/obj/structure/window/spawner/north,
-/turf/open/floor/iron/dark/textured_large,
-/area/station/service/hydroponics/garden)
 "DB" = (
 /obj/structure/cable,
 /obj/structure/closet/emcloset/wall{
@@ -8863,10 +8896,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "GC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "GD" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/gravity_generator)
@@ -8963,18 +8997,6 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/station/service/kitchen)
-"GV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "GW" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/firealarm/directional/south,
@@ -9274,10 +9296,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/fore)
-"Id" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/crew_quarters/dorms)
 "Ie" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9539,6 +9557,11 @@
 /obj/item/target,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/range)
+"IT" = (
+/obj/item/stack/rods/two,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "IW" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/smooth_large,
@@ -9579,6 +9602,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/science)
+"Jc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "Jd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9900,6 +9930,10 @@
 /obj/effect/landmark/start/scoundrel/deckhand,
 /turf/open/floor/wood/large,
 /area/station/service/bar)
+"Kr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/science/research/abandoned)
 "Ks" = (
 /obj/structure/cable,
 /obj/item/assembly/mousetrap/armed,
@@ -10007,14 +10041,6 @@
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/fore)
-"KK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing,
-/obj/structure/marker_beacon/burgundy,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "KL" = (
 /obj/machinery/gateway/centerstation,
 /turf/open/floor/stone,
@@ -10242,9 +10268,13 @@
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/command/heads_quarters/captain)
 "LA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/science/research/abandoned)
+/obj/effect/turf_decal/tile/yellow/half/contrasted,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "n2 pump"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "LC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10366,13 +10396,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
-"LZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "Ma" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
@@ -10745,11 +10768,6 @@
 /obj/structure/marker_beacon/burgundy,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"Nk" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Nn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
@@ -10911,10 +10929,6 @@
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/awaymission/secret/powered)
-"NO" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "NP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/large,
@@ -11019,6 +11033,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"Ol" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "On" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11114,6 +11134,10 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood/large,
 /area/station/service/cafeteria)
+"OH" = (
+/obj/structure/railing/corner,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "OI" = (
 /obj/item/kirbyplants,
 /turf/open/floor/wood/large,
@@ -11355,11 +11379,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
-"PC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/fire/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "PD" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark/textured,
@@ -11486,14 +11505,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
-"Qf" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Qg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11632,12 +11643,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/lobby)
-"QJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "QK" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/curtain,
@@ -11672,14 +11677,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"QT" = (
-/obj/structure/cable,
-/obj/structure/sign/warning/vacuum/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/solars/starboard)
 "QU" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -12226,13 +12223,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/space/basic,
 /area/space/nearstation)
-"SW" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent/layer2{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "SX" = (
 /obj/structure/chair{
 	dir = 4
@@ -12437,10 +12427,15 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "TP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/science/research/abandoned)
+/area/station/maintenance/solars/starboard)
 "TQ" = (
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
@@ -12499,6 +12494,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
+"TZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/airless,
+/area/space/nearstation/nostarlight)
 "Ua" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/mech_bay_recharge_port{
@@ -12597,14 +12597,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
-"Ut" = (
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/airless,
-/area/space/nearstation/nostarlight)
 "Uu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12632,16 +12624,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/solars/port)
-"Uy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/solars/starboard)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13424,6 +13406,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/service/bar)
+"Xq" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/solars/starboard)
 "Xr" = (
 /obj/structure/fans/tiny,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13440,6 +13433,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/awaymission/secret/powered)
+"Xs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "Xt" = (
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /obj/effect/turf_decal/tile/green{
@@ -13646,6 +13644,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
+"Ye" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "Yg" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
@@ -14126,10 +14131,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/airless,
 /area/space/nearstation/nostarlight)
-"ZV" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/department/crew_quarters/dorms)
 "ZW" = (
 /turf/open/floor/engine,
 /area/station/science/research/abandoned)
@@ -43832,12 +43833,12 @@ xJ
 RS
 wB
 Gj
-ZV
+aF
 mt
 mt
 RC
 nt
-Id
+hS
 nt
 dN
 dN
@@ -44826,7 +44827,7 @@ An
 PW
 PW
 PW
-DA
+hn
 GW
 we
 cN
@@ -44854,9 +44855,9 @@ iM
 rM
 Wg
 YH
-aS
+nD
 YH
-KK
+jo
 dN
 dN
 dN
@@ -46657,16 +46658,16 @@ pp
 eW
 pp
 dN
-cZ
+kz
 wo
-cZ
-cZ
-cZ
-cZ
-cZ
-cZ
+kz
+kz
+kz
+kz
+kz
+kz
 wo
-cZ
+kz
 dN
 dN
 Ig
@@ -47169,7 +47170,7 @@ Mi
 Mi
 Mi
 eW
-nD
+IT
 dN
 in
 wo
@@ -47427,16 +47428,16 @@ dN
 pp
 eW
 pp
-fB
-pp
 ft
 pp
+wb
 pp
 pp
-nD
+pp
+IT
 pp
 pp
-ft
+wb
 pp
 pp
 dN
@@ -47695,7 +47696,7 @@ NZ
 wo
 wo
 wo
-Nk
+cZ
 tP
 Ig
 dN
@@ -47940,7 +47941,7 @@ dN
 dN
 pp
 SV
-gh
+xY
 pp
 pp
 NZ
@@ -50767,9 +50768,9 @@ Pq
 Pq
 Pq
 Pq
-GC
-Qf
-Ut
+TZ
+dM
+gt
 dN
 dN
 dN
@@ -51020,13 +51021,13 @@ ym
 ys
 ys
 Pq
-bT
-fd
-QT
+fB
+Xq
+aj
 Pq
 Pq
 Pq
-jo
+ji
 pp
 Ig
 Ig
@@ -51275,14 +51276,14 @@ Uf
 IB
 ey
 ys
-QJ
-kZ
-pA
-uD
-pA
-Uy
+cT
+fP
+Ol
+kg
+Ol
+TP
+aR
 zp
-GV
 eW
 wo
 wo
@@ -51795,9 +51796,9 @@ Pq
 Pq
 Pq
 Pq
-kz
+OH
 PK
-qr
+vD
 dN
 dN
 Ig
@@ -52049,7 +52050,7 @@ YN
 Bn
 Bn
 Bn
-NO
+xH
 ys
 pj
 BF
@@ -52555,7 +52556,7 @@ En
 Xk
 Fj
 AE
-iK
+GC
 qP
 qP
 Dz
@@ -52817,7 +52818,7 @@ qP
 ty
 HB
 HB
-ti
+wQ
 CQ
 Gs
 ST
@@ -53331,7 +53332,7 @@ YF
 dW
 dW
 dW
-wQ
+LA
 ix
 Hr
 tX
@@ -54117,7 +54118,7 @@ if
 CZ
 pp
 pp
-ft
+wb
 pp
 pp
 pp
@@ -54381,7 +54382,7 @@ pj
 pj
 pj
 pj
-cl
+sH
 wo
 Eh
 pp
@@ -54634,7 +54635,7 @@ pp
 NZ
 pp
 pp
-fB
+ft
 pp
 pp
 pp
@@ -55117,11 +55118,11 @@ cK
 fz
 NH
 bH
-br
+qZ
 JL
-dP
-br
-fX
+Cl
+qZ
+ck
 NH
 zv
 GL
@@ -56926,7 +56927,7 @@ Ok
 Fk
 CP
 CP
-PC
+Xs
 ys
 lj
 ys
@@ -57180,8 +57181,8 @@ Dc
 LP
 LP
 Uv
-mY
-LZ
+Jc
+Ye
 xj
 Kw
 pI
@@ -65144,7 +65145,7 @@ dN
 dN
 FP
 Ki
-ji
+ai
 fZ
 Bc
 qk
@@ -65658,8 +65659,8 @@ dN
 dN
 FP
 fl
-TP
-LA
+zS
+bT
 sl
 FP
 Xv
@@ -65916,7 +65917,7 @@ dN
 oH
 ih
 fa
-LA
+bT
 rq
 FP
 Bs
@@ -66430,7 +66431,7 @@ pp
 oH
 FP
 oH
-vD
+Kr
 FP
 oH
 FP
@@ -66687,7 +66688,7 @@ Mi
 Mi
 pp
 Mi
-SW
+AG
 pp
 FP
 FP

--- a/_maps/templates/construction_pod.dmm
+++ b/_maps/templates/construction_pod.dmm
@@ -18,6 +18,10 @@
 "p" = (
 /turf/template_noop,
 /area/template_noop)
+"r" = (
+/obj/item/electronics/apc,
+/turf/open/floor/plating,
+/area/space/nearstation/nostarlight)
 "z" = (
 /turf/open/floor/plating,
 /area/space/nearstation/nostarlight)
@@ -82,7 +86,7 @@ C
 z
 z
 A
-z
+r
 z
 z
 z

--- a/code/game/area/areas/misc.dm
+++ b/code/game/area/areas/misc.dm
@@ -41,5 +41,3 @@
 	area_flags = UNIQUE_AREA
 	static_lighting = TRUE
 	base_lighting_alpha = 0
-	power_light = TRUE
-	always_unpowered = FALSE


### PR DESCRIPTION
## About The Pull Request
## Why It's Good For The Game
## Changelog
:cl:
add: added more extinguishers, heaters and oxygen canisters to freebooter
add: added dividing windows to some of the hydroponic trays on freebooter
add: added science scanners to freebooter
add: you can now find a significant research note in the vault's safe on freebooter
add: tcomms on freebooter now has an SMES
add: you can now find a spare solars crate in engineering storage on freebooter'
add: the captain's jetpack can now be found in the captain's locker
del: captain's modsuit is no longer obtainable
balance: the number of tumblers on the vault's safe on freebooter has been reduced from 5 to 3
balance: solars has been divided into two smaller sections
fix: fixed the direction of the turbine SMES on freebooter
fix: added some missing connectors to the turbine on freebooter
fix: the o2 and n2 pumps on freebooter are now labeled
fix: added some basic functionality to the atmos in the abandoned xenobio lab
fix: apc circuit added to the construction pod
fix: you can no longer construct APCs in some spaces you shouldn't be able to
/:cl:
