### PR TITLE
More bomb balance

### DIFF
--- a/code/__DEFINES/machines.dm
+++ b/code/__DEFINES/machines.dm
@@ -137,4 +137,4 @@
 #define TLV_OUTSIDE_HAZARD_LIMIT 2
 
 /// What's the minimum duration of a syndie bomb (in seconds)
-#define SYNDIEBOMB_MIN_TIMER_SECONDS 90
+#define SYNDIEBOMB_MIN_TIMER_SECONDS 120

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -452,8 +452,10 @@ REACTIONARY_EXPLOSIONS
 ## eg: If you give the number 20. The bomb cap will be 5,10,20.
 ## Can be any number above 4, some examples are provided below.
 
+## Extrasmall
+BOMBCAP 10
 ## Small (3, 7, 14)
-BOMBCAP 14
+#BOMBCAP 14
 ## Default (5, 10, 20) (recommended if you enable REACTIONARY_EXPLOSIONS above)
 #BOMBCAP 20
 ## LagHell (7, 14, 28)


### PR DESCRIPTION

## About The Pull Request
syndicate bomb timer raised from 90 to 120, bombcap lowered from 14 to 10
## Why It's Good For The Game
## Changelog
:cl:
balance: the syndicate bomb's timer has been raised from 90 to 120 seconds
config: the bomb cap has been lowered from 14 to 10
/:cl:
