### PR TITLE
Economy Rework - Pt. 1: No More Free Materials (Kind Of)

### DIFF
--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -38,11 +38,13 @@
 	var/cost_modifier = 1
 	/// The minimum required amount of credits in a bank account to consider giving refunds for inserting materials. Currently the same as cargo gets roundstart.
 	var/refund_minimum = MINIMUM_REFUND_THRESHOLD
+	/// whether or not this component belongs to an ore silo !!!! SHITCODE WARNING!!!!
+	var/ore_silo_storage = FALSE
 	/// The material container flags. See __DEFINES/materials.dm.
 	var/mat_container_flags
 
 /// Sets up the proper signals and fills the list of materials with the appropriate references.
-/datum/component/material_container/Initialize(list/init_mats, max_amt = 0, _mat_container_flags=NONE, list/allowed_mats=init_mats, list/allowed_items, datum/callback/_insertion_check, datum/callback/_precondition, datum/callback/_after_insert)
+/datum/component/material_container/Initialize(list/init_mats, max_amt = 0, _mat_container_flags=NONE, list/allowed_mats=init_mats, list/allowed_items, datum/callback/_insertion_check, datum/callback/_precondition, datum/callback/_after_insert, ore_silo=FALSE)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -69,6 +71,8 @@
 		if(isnull(mat_amt))
 			mat_amt = 0
 		materials[mat_ref] += mat_amt
+	if(ore_silo)
+		ore_silo_storage = TRUE
 
 /datum/component/material_container/Destroy(force, silent)
 	materials = null

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -71,7 +71,8 @@
 		if(isnull(mat_amt))
 			mat_amt = 0
 		materials[mat_ref] += mat_amt
-	ore_silo_storage = ore_silo
+	if(ore_silo)
+		ore_silo_storage = TRUE
 
 /datum/component/material_container/Destroy(force, silent)
 	materials = null

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -9,7 +9,7 @@
 		MAX_STACK_SIZE - size of a stack of mineral sheets. Constant.
 */
 
-#define MINIMUM_REFUND_THRESHOLD 5000
+#define MINIMUM_REFUND_THRESHOLD 1000
 
 /datum/component/material_container
 	/// The total amount of materials this material container contains
@@ -37,7 +37,7 @@
 	/// Modifier for all materials drawn when there's a linked account.
 	var/cost_modifier = 1
 	/// The minimum required amount of credits in a bank account to consider giving refunds for inserting materials. Currently the same as cargo gets roundstart.
-	var/refund_minimum = 5000
+	var/refund_minimum = MINIMUM_REFUND_THRESHOLD
 	/// The material container flags. See __DEFINES/materials.dm.
 	var/mat_container_flags
 

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -71,8 +71,7 @@
 		if(isnull(mat_amt))
 			mat_amt = 0
 		materials[mat_ref] += mat_amt
-	if(ore_silo)
-		ore_silo_storage = TRUE
+	ore_silo_storage = ore_silo
 
 /datum/component/material_container/Destroy(force, silent)
 	materials = null

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -416,10 +416,10 @@
   * * round - Whether or not to round the cost. **MORE IMPORTANT THAN IT SEEMS, IT COULD MEAN THE DIFFERENCE BETWEEN 2000cr AND 25cr!!**
   */
 /datum/component/material_container/proc/get_material_cost(datum/material/mat, amt = 1, round = TRUE)
-	if(GLOB.security_level >= SEC_LEVEL_RED)
+	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED)
 		return FALSE //It's free when it's an emergency, don't want to prevent everyone from helping
 	if(!istype(mat))
-		mat = SSmaterials.GetMaterialRef(mat) //Get the ref if necesary
+		mat = SSmaterials._GetMaterialRef(mat) //Get the ref if necesary
 
 	var/total_cost = amt * mat.value_per_unit * cost_modifier
 	if(!linked_account)

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -38,13 +38,11 @@
 	var/cost_modifier = 1
 	/// The minimum required amount of credits in a bank account to consider giving refunds for inserting materials. Currently the same as cargo gets roundstart.
 	var/refund_minimum = MINIMUM_REFUND_THRESHOLD
-	/// whether or not this component belongs to an ore silo !!!! SHITCODE WARNING!!!!
-	var/ore_silo_storage = FALSE
 	/// The material container flags. See __DEFINES/materials.dm.
 	var/mat_container_flags
 
 /// Sets up the proper signals and fills the list of materials with the appropriate references.
-/datum/component/material_container/Initialize(list/init_mats, max_amt = 0, _mat_container_flags=NONE, list/allowed_mats=init_mats, list/allowed_items, datum/callback/_insertion_check, datum/callback/_precondition, datum/callback/_after_insert, ore_silo=FALSE)
+/datum/component/material_container/Initialize(list/init_mats, max_amt = 0, _mat_container_flags=NONE, list/allowed_mats=init_mats, list/allowed_items, datum/callback/_insertion_check, datum/callback/_precondition, datum/callback/_after_insert)
 	if(!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -71,8 +69,6 @@
 		if(isnull(mat_amt))
 			mat_amt = 0
 		materials[mat_ref] += mat_amt
-	if(ore_silo)
-		ore_silo_storage = TRUE
 
 /datum/component/material_container/Destroy(force, silent)
 	materials = null

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -6,32 +6,25 @@ handles linking back and forth.
 */
 
 /datum/component/remote_materials
-	// ~~Three~~ Four? possible states:
-	// 1. silo exists, materials is parented to silo, parent held in inactive_container
-	// 2. silo exists, materials is parented to parent, silo is held in inactive_container
-	// 3. silo is null, materials is parented to parent
-	// 4. silo is null, materials is null
+	// Three possible states:
+	// 1. silo exists, materials is parented to silo
+	// 2. silo is null, materials is parented to parent
+	// 3. silo is null, materials is null
 	var/obj/machinery/ore_silo/silo
-	// the active mat container. this swaps places with inactive_container
 	var/datum/component/material_container/mat_container
-	var/datum/component/material_container/inactive_container
-	// whether or not tu use legacy behavior when making local. essentially means can only ever have ore silo storage or local storage, never both at once
-	var/single_storage
 	var/category
 	var/allow_standalone
 	var/local_size = INFINITY
 	///Flags used when converting inserted materials into their component materials.
 	var/mat_container_flags = NONE
 
-/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, mat_container_flags=NONE, single_storage=TRUE)
+/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, mat_container_flags=NONE)
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	src.category = category
 	src.allow_standalone = allow_standalone
 	src.mat_container_flags = mat_container_flags
-	src.single_storage = single_storage
-
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(OnAttackBy))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(OnMultitool))
@@ -42,8 +35,6 @@ handles linking back and forth.
 		addtimer(CALLBACK(src, PROC_REF(LateInitialize)))
 	else if (allow_standalone)
 		_MakeLocal()
-	if (!single_storage)
-		inactive_container = gen_local_storage()
 
 /datum/component/remote_materials/proc/LateInitialize()
 	silo = GLOB.ore_silo_default
@@ -54,32 +45,20 @@ handles linking back and forth.
 		_MakeLocal()
 
 /datum/component/remote_materials/Destroy()
-	var/atom/P = parent
 	if (silo)
 		silo.ore_connected_machines -= src
 		silo.updateUsrDialog()
 		silo = null
-		if(mat_container.ore_silo_storage)
-			mat_container = null
-		else
-			inactive_container = null
-	if (mat_container)
-		mat_container.retrieve_all(P.drop_location())
-	if (inactive_container)
+		mat_container = null
+	else if (mat_container)
+		// specify explicitly in case the other component is deleted first
+		var/atom/P = parent
 		mat_container.retrieve_all(P.drop_location())
 	return ..()
 
 /datum/component/remote_materials/proc/_MakeLocal()
 	silo = null
 
-	if(inactive_container)
-		mat_container = inactive_container
-		inactive_container = null
-	else
-		mat_container = gen_local_storage()
-
-// returns the local storage, should assign it to a var whenever its called
-/datum/component/remote_materials/proc/gen_local_storage()
 	var/static/list/allowed_mats = list(
 		/datum/material/iron,
 		/datum/material/glass,
@@ -94,38 +73,26 @@ handles linking back and forth.
 		/datum/material/plastic,
 		)
 
-	return parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
-
-/datum/component/remote_materials/proc/swap_storage()
-	var/datum/component/material_container/temp = mat_container
-	mat_container = inactive_container
-	inactive_container = temp
+	mat_container = parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
 
 /datum/component/remote_materials/proc/set_local_size(size)
 	local_size = size
-	//if (!silo && mat_container)
-	//	mat_container.max_amount = local_size
-	if (mat_container && !mat_container.ore_silo_storage)
-		mat_container.max_amount = local_size
-	else if (!single_storage)
-		inactive_container.max_amount = local_size
+	if (!silo && mat_container)
+		mat_container.max_amount = size
 
 // called if disconnected by ore silo UI or destruction
 /datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
 	if (!old_silo || silo != old_silo)
 		return
 	silo = null
-	if(mat_container && mat_container.ore_silo_storage)
-		mat_container = null
-	else
-		inactive_container = null
+	mat_container = null
 	if (allow_standalone)
 		_MakeLocal()
 
 /datum/component/remote_materials/proc/OnAttackBy(datum/source, obj/item/I, mob/user)
 	SIGNAL_HANDLER
 
-	if (silo && mat_container.ore_silo_storage && isstack(I))
+	if (silo && isstack(I))
 		if (silo.remote_attackby(parent, user, I, mat_container_flags))
 			return COMPONENT_NO_AFTERATTACK
 
@@ -148,12 +115,8 @@ handles linking back and forth.
 			silo.ore_connected_machines -= src
 			silo.updateUsrDialog()
 		else if (mat_container)
-			if (single_storage)
-				mat_container.retrieve_all()
-				qdel(mat_container)
-			else
-				inactive_container = mat_container
-				to_chat(user, span_notice("Local storage moved to inactive standby."))
+			mat_container.retrieve_all()
+			qdel(mat_container)
 		silo = M.buffer
 		silo.ore_connected_machines += src
 		silo.updateUsrDialog()
@@ -174,12 +137,12 @@ handles linking back and forth.
 	return silo?.holds["[get_area(parent)]/[category]"]
 
 /datum/component/remote_materials/proc/silo_log(obj/machinery/M, action, amount, noun, list/mats)
-	if (silo && mat_container.ore_silo_storage)
+	if (silo)
 		silo.silo_log(M || parent, action, amount, noun, mats)
 
 /datum/component/remote_materials/proc/format_amount()
 	if (mat_container)
-		return "[mat_container.total_amount] / [mat_container.max_amount == INFINITY ? "Unlimited" : mat_container.max_amount] ([mat_container.ore_silo_storage ? "remote" : "local"])"
+		return "[mat_container.total_amount] / [mat_container.max_amount == INFINITY ? "Unlimited" : mat_container.max_amount] ([silo ? "remote" : "local"])"
 	else
 		return "0 / 0"
 
@@ -192,7 +155,7 @@ handles linking back and forth.
 	if (!mat_container)
 		movable_parent.say("No access to material storage, please contact the quartermaster.")
 		return 0
-	if (mat_container.ore_silo_storage && on_hold())
+	if (on_hold())
 		movable_parent.say("Mineral access is on hold, please contact the quartermaster.")
 		return 0
 	var/count = mat_container.retrieve_sheets(eject_amount, material_ref, movable_parent.drop_location())

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -6,25 +6,32 @@ handles linking back and forth.
 */
 
 /datum/component/remote_materials
-	// Three possible states:
-	// 1. silo exists, materials is parented to silo
-	// 2. silo is null, materials is parented to parent
-	// 3. silo is null, materials is null
+	// ~~Three~~ Four? possible states:
+	// 1. silo exists, materials is parented to silo, parent held in inactive_container
+	// 2. silo exists, materials is parented to parent, silo is held in inactive_container
+	// 3. silo is null, materials is parented to parent
+	// 4. silo is null, materials is null
 	var/obj/machinery/ore_silo/silo
+	// the active mat container. this swaps places with inactive_container
 	var/datum/component/material_container/mat_container
+	var/datum/component/material_container/inactive_container
+	// whether or not tu use legacy behavior when making local. essentially means can only ever have ore silo storage or local storage, never both at once
+	var/single_storage
 	var/category
 	var/allow_standalone
 	var/local_size = INFINITY
 	///Flags used when converting inserted materials into their component materials.
 	var/mat_container_flags = NONE
 
-/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, mat_container_flags=NONE)
+/datum/component/remote_materials/Initialize(category, mapload, allow_standalone = TRUE, force_connect = FALSE, mat_container_flags=NONE, single_storage=TRUE)
 	if (!isatom(parent))
 		return COMPONENT_INCOMPATIBLE
 
 	src.category = category
 	src.allow_standalone = allow_standalone
 	src.mat_container_flags = mat_container_flags
+	src.single_storage = single_storage
+
 
 	RegisterSignal(parent, COMSIG_PARENT_ATTACKBY, PROC_REF(OnAttackBy))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(OnMultitool))
@@ -35,6 +42,8 @@ handles linking back and forth.
 		addtimer(CALLBACK(src, PROC_REF(LateInitialize)))
 	else if (allow_standalone)
 		_MakeLocal()
+	if (!single_storage)
+		inactive_container = gen_local_storage()
 
 /datum/component/remote_materials/proc/LateInitialize()
 	silo = GLOB.ore_silo_default
@@ -45,20 +54,32 @@ handles linking back and forth.
 		_MakeLocal()
 
 /datum/component/remote_materials/Destroy()
+	var/atom/P = parent
 	if (silo)
 		silo.ore_connected_machines -= src
 		silo.updateUsrDialog()
 		silo = null
-		mat_container = null
-	else if (mat_container)
-		// specify explicitly in case the other component is deleted first
-		var/atom/P = parent
+		if(mat_container.ore_silo_storage)
+			mat_container = null
+		else
+			inactive_container = null
+	if (mat_container)
+		mat_container.retrieve_all(P.drop_location())
+	if (inactive_container)
 		mat_container.retrieve_all(P.drop_location())
 	return ..()
 
 /datum/component/remote_materials/proc/_MakeLocal()
 	silo = null
 
+	if(inactive_container)
+		mat_container = inactive_container
+		inactive_container = null
+	else
+		mat_container = gen_local_storage()
+
+// returns the local storage, should assign it to a var whenever its called
+/datum/component/remote_materials/proc/gen_local_storage()
 	var/static/list/allowed_mats = list(
 		/datum/material/iron,
 		/datum/material/glass,
@@ -73,26 +94,38 @@ handles linking back and forth.
 		/datum/material/plastic,
 		)
 
-	mat_container = parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
+	return parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
+
+/datum/component/remote_materials/proc/swap_storage()
+	var/datum/component/material_container/temp = mat_container
+	mat_container = inactive_container
+	inactive_container = temp
 
 /datum/component/remote_materials/proc/set_local_size(size)
 	local_size = size
-	if (!silo && mat_container)
-		mat_container.max_amount = size
+	//if (!silo && mat_container)
+	//	mat_container.max_amount = local_size
+	if (mat_container && !mat_container.ore_silo_storage)
+		mat_container.max_amount = local_size
+	else if (!single_storage)
+		inactive_container.max_amount = local_size
 
 // called if disconnected by ore silo UI or destruction
 /datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
 	if (!old_silo || silo != old_silo)
 		return
 	silo = null
-	mat_container = null
+	if(mat_container && mat_container.ore_silo_storage)
+		mat_container = null
+	else
+		inactive_container = null
 	if (allow_standalone)
 		_MakeLocal()
 
 /datum/component/remote_materials/proc/OnAttackBy(datum/source, obj/item/I, mob/user)
 	SIGNAL_HANDLER
 
-	if (silo && isstack(I))
+	if (silo && mat_container.ore_silo_storage && isstack(I))
 		if (silo.remote_attackby(parent, user, I, mat_container_flags))
 			return COMPONENT_NO_AFTERATTACK
 
@@ -115,8 +148,12 @@ handles linking back and forth.
 			silo.ore_connected_machines -= src
 			silo.updateUsrDialog()
 		else if (mat_container)
-			mat_container.retrieve_all()
-			qdel(mat_container)
+			if (single_storage)
+				mat_container.retrieve_all()
+				qdel(mat_container)
+			else
+				inactive_container = mat_container
+				to_chat(user, span_notice("Local storage moved to inactive standby."))
 		silo = M.buffer
 		silo.ore_connected_machines += src
 		silo.updateUsrDialog()
@@ -137,12 +174,12 @@ handles linking back and forth.
 	return silo?.holds["[get_area(parent)]/[category]"]
 
 /datum/component/remote_materials/proc/silo_log(obj/machinery/M, action, amount, noun, list/mats)
-	if (silo)
+	if (silo && mat_container.ore_silo_storage)
 		silo.silo_log(M || parent, action, amount, noun, mats)
 
 /datum/component/remote_materials/proc/format_amount()
 	if (mat_container)
-		return "[mat_container.total_amount] / [mat_container.max_amount == INFINITY ? "Unlimited" : mat_container.max_amount] ([silo ? "remote" : "local"])"
+		return "[mat_container.total_amount] / [mat_container.max_amount == INFINITY ? "Unlimited" : mat_container.max_amount] ([mat_container.ore_silo_storage ? "remote" : "local"])"
 	else
 		return "0 / 0"
 
@@ -155,7 +192,7 @@ handles linking back and forth.
 	if (!mat_container)
 		movable_parent.say("No access to material storage, please contact the quartermaster.")
 		return 0
-	if (on_hold())
+	if (mat_container.ore_silo_storage && on_hold())
 		movable_parent.say("Mineral access is on hold, please contact the quartermaster.")
 		return 0
 	var/count = mat_container.retrieve_sheets(eject_amount, material_ref, movable_parent.drop_location())

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -161,11 +161,11 @@ RLD
 			return FALSE
 		var/list/materials = list()
 		materials[GET_MATERIAL_REF(/datum/material/iron)] = 500
-		var/obj/item/card/id/card = user.get_idcard()
-		if(!card.registered_account.has_money(silo_mats.mat_container.get_material_list_cost(list(/datum/material/iron = 500), amount)))
+		var/datum/bank_account/user_account = user.get_bank_account()
+		if(user_account.has_money(silo_mats.mat_container.get_material_list_cost(list(/datum/material/iron = 500), amount)))
 			to_chat(user, "<span class='alert'>Not enough credits to use material.</span>")
 			return FALSE
-		silo_mats.mat_container.use_materials(materials, amount, card.registered_account)
+		silo_mats.mat_container.use_materials(materials, amount, user_account)
 		silo_mats.silo_log(src, "consume", -amount, "build", materials)
 		return TRUE
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -159,10 +159,13 @@ RLD
 			if(user)
 				to_chat(user, no_ammo_message)
 			return FALSE
-
 		var/list/materials = list()
 		materials[GET_MATERIAL_REF(/datum/material/iron)] = 500
-		silo_mats.mat_container.use_materials(materials, amount)
+		var/obj/item/card/id/card = user.get_idcard()
+		if(!card.registered_account.has_money(silo_mats.mat_container.get_material_list_cost(list(/datum/material/iron = 500), amount)))
+			to_chat(user, "<span class='alert'>Not enough credits to use material.</span>")
+			return FALSE
+		silo_mats.mat_container.use_materials(materials, amount, card.registered_account)
 		silo_mats.silo_log(src, "consume", -amount, "build", materials)
 		return TRUE
 

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -126,7 +126,7 @@
  * * transfer_reason - override for adjust_money reason. Use if no default reason(Transfer to/from Name Surname).
  */
 /datum/bank_account/proc/transfer_money(datum/bank_account/from, amount, transfer_reason)
-	if(from.has_money(amount))
+	if(from?.has_money(amount))
 		var/reason_to = "Transfer: From [from.account_holder]"
 		var/reason_from = "Transfer: To [account_holder]"
 

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -234,12 +234,12 @@
 	var/datum/material/mat = selected_material
 	if(!mat)
 		return
-	var/sheets_to_remove = (materials.materials[mat] >= (MINERAL_MATERIAL_AMOUNT * SMELT_AMOUNT * delta_time) ) ? SMELT_AMOUNT * delta_time : round(materials.materials[mat] /  MINERAL_MATERIAL_AMOUNT)
-	if(!sheets_to_remove)
-		on = FALSE
-	else
-		var/out = get_step(src, output_dir)
-		materials.retrieve_sheets(sheets_to_remove, mat, out)
+		var/sheets_to_remove = (materials.materials[mat] >= (MINERAL_MATERIAL_AMOUNT * SMELT_AMOUNT * delta_time) ) ? SMELT_AMOUNT : round(materials.materials[mat] /  MINERAL_MATERIAL_AMOUNT)
+		if(!sheets_to_remove)
+			on = FALSE
+		else
+			var/out = get_step(src, output_dir)
+			materials.retrieve_sheets(sheets_to_remove, mat, out, SSeconomy.get_dep_account(ACCOUNT_CAR))
 
 /obj/machinery/mineral/processing_unit/proc/smelt_alloy(delta_time = 2)
 	var/datum/design/alloy = stored_research.isDesignResearchedID(selected_alloy) //check if it's a valid design

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -234,12 +234,12 @@
 	var/datum/material/mat = selected_material
 	if(!mat)
 		return
-		var/sheets_to_remove = (materials.materials[mat] >= (MINERAL_MATERIAL_AMOUNT * SMELT_AMOUNT * delta_time) ) ? SMELT_AMOUNT : round(materials.materials[mat] /  MINERAL_MATERIAL_AMOUNT)
-		if(!sheets_to_remove)
-			on = FALSE
-		else
-			var/out = get_step(src, output_dir)
-			materials.retrieve_sheets(sheets_to_remove, mat, out, SSeconomy.get_dep_account(ACCOUNT_CAR))
+	var/sheets_to_remove = (materials.materials[mat] >= (MINERAL_MATERIAL_AMOUNT * SMELT_AMOUNT * delta_time) ) ? SMELT_AMOUNT * delta_time : round(materials.materials[mat] /  MINERAL_MATERIAL_AMOUNT)
+	if(!sheets_to_remove)
+		on = FALSE
+	else
+		var/out = get_step(src, output_dir)
+		materials.retrieve_sheets(sheets_to_remove, mat, out, SSeconomy.get_dep_account(ACCOUNT_CAR))
 
 /obj/machinery/mineral/processing_unit/proc/smelt_alloy(delta_time = 2)
 	var/datum/design/alloy = stored_research.isDesignResearchedID(selected_alloy) //check if it's a valid design

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -265,7 +265,7 @@
 				to_chat(usr, span_warning("No points to claim."))
 			return TRUE
 		if("Release")
-			var/obj/item/card/id/I = usr.get_idcard(TRUE)
+			var/datum/bank_account/user_account = usr.get_bank_account(TRUE)
 			if(!mat_container)
 				return
 			if(materials.on_hold())
@@ -293,7 +293,7 @@
 						return
 				var/sheets_to_remove = round(min(desired,50,stored_amount))
 
-				var/count = mat_container.retrieve_sheets(sheets_to_remove, mat, get_step(src, output_dir), I?.registered_account)
+				var/count = mat_container.retrieve_sheets(sheets_to_remove, mat, get_step(src, output_dir), user_account)
 				var/list/mats = list()
 				mats[mat] = MINERAL_MATERIAL_AMOUNT
 				materials.silo_log(src, "released", -count, "sheets", mats)

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -8,7 +8,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	icon_state = "silo"
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/ore_silo
-	req_access = ACCESS_VAULT
+	req_access = list(ACCESS_VAULT)
 
 	/// The machine UI's page of logs showing ore history.
 	var/log_page = 1

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -196,10 +196,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		updateUsrDialog()
 		return TRUE
 	else if(href_list["ejectsheet"])
-		var/obj/item/card/id/I = usr.get_idcard(TRUE)
+		var/datum/bank_account/account = usr.get_bank_account(TRUE)
 		var/datum/material/eject_sheet = locate(href_list["ejectsheet"])
 		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-		var/count = materials.retrieve_sheets(text2num(href_list["eject_amt"]), eject_sheet, drop_location(), I?.registered_account)
+		var/count = materials.retrieve_sheets(text2num(href_list["eject_amt"]), eject_sheet, drop_location(), account)
 		var/list/matlist = list()
 		matlist[eject_sheet] = MINERAL_MATERIAL_AMOUNT
 		silo_log(src, "ejected", -count, "sheets", matlist)

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -8,6 +8,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	icon_state = "silo"
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/ore_silo
+	req_access = ACCESS_VAULT
 
 	/// The machine UI's page of logs showing ore history.
 	var/log_page = 1
@@ -31,9 +32,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		/datum/material/bluespace,
 		/datum/material/plastic,
 		)
-	AddComponent(/datum/component/material_container, materials_list, INFINITY, MATCONTAINER_NO_INSERT, allowed_items=/obj/item/stack)
+	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container, materials_list, INFINITY, MATCONTAINER_NO_INSERT, allowed_items=/obj/item/stack)
 	if (!GLOB.ore_silo_default && mapload && is_station_level(z))
 		GLOB.ore_silo_default = src
+		materials.linked_account = SSeconomy.get_dep_account(ACCOUNT_CAR)
 
 /obj/machinery/ore_silo/Destroy()
 	if (GLOB.ore_silo_default == src)
@@ -81,7 +83,29 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 
 	if (isstack(W))
 		return remote_attackby(src, user, W)
-
+	if (istype(W, /obj/item/card/id))
+		var/obj/item/card/id/card = W
+		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
+		if(materials.linked_account && (card.registered_account == materials.linked_account || check_access(card)))
+			var/choice = input(user, "Please select a configuration option.", "Ore Silo") as null|anything in list("Unlink Account", "Change Markup", "Minimum Refund Threshold")
+			switch(choice)
+				if("Change Markup")
+					var/markup = clamp(input(user, "Please input the desired material markup cost. (Number, 0%-500%)", "Ore Silo", materials.cost_modifier * 100) as num, 0, 500)
+					if(markup)
+						materials.cost_modifier = markup / 100
+				if("Unlink Account")
+					materials.linked_account.bank_card_talk("[src] has been un-linked from your account.")
+					materials.linked_account = null
+				if("Minimum Refund Threshold")
+					var/threshold = max(input(user, "Please input the desired minimum balance at which to consider giving material price refunds. (Number, Minimum 0)", "Ore Silo", materials.refund_minimum) as num, 0)
+					if(threshold)
+						materials.refund_minimum = threshold
+		else if(!materials.linked_account && card.registered_account)
+			user.visible_message("[user] swipes [card] on [src], registering its linked account for material payments.", \
+			 					 "You swipe [card] on [src], registering its linked account for material payments.", \
+								 "You hear a someone sliding a card, and then a quiet beep.")
+			materials.linked_account = card.registered_account
+		return TRUE
 	return ..()
 
 /obj/machinery/ore_silo/ui_interact(mob/user)
@@ -92,7 +116,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 
 /obj/machinery/ore_silo/proc/generate_ui()
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-	var/list/ui = list("<head><title>Ore Silo</title></head><body><div class='statusDisplay'><h2>Stored Material:</h2>")
+	var/list/ui = list("<head><title>Ore Silo</title></head><body><div class='statusDisplay'>")
+	if(materials.linked_account)
+		ui += "<b>Linked account:</b> [materials.linked_account.account_holder]'s account ([materials.cost_modifier * 100]% markup)"
+	ui += "<h2>Stored Material:</h2>"
 	var/any = FALSE
 	for(var/M in materials.materials)
 		var/datum/material/mat = M
@@ -169,9 +196,10 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		updateUsrDialog()
 		return TRUE
 	else if(href_list["ejectsheet"])
+		var/obj/item/card/id/I = usr.get_idcard(TRUE)
 		var/datum/material/eject_sheet = locate(href_list["ejectsheet"])
 		var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
-		var/count = materials.retrieve_sheets(text2num(href_list["eject_amt"]), eject_sheet, drop_location())
+		var/count = materials.retrieve_sheets(text2num(href_list["eject_amt"]), eject_sheet, drop_location(), I?.registered_account)
 		var/list/matlist = list()
 		matlist[eject_sheet] = MINERAL_MATERIAL_AMOUNT
 		silo_log(src, "ejected", -count, "sheets", matlist)

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		/datum/material/bluespace,
 		/datum/material/plastic,
 		)
-	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container, materials_list, INFINITY, MATCONTAINER_NO_INSERT, allowed_items=/obj/item/stack)
+	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container, materials_list, INFINITY, MATCONTAINER_NO_INSERT, allowed_items=/obj/item/stack, ore_silo=TRUE)
 	if (!GLOB.ore_silo_default && mapload && is_station_level(z))
 		GLOB.ore_silo_default = src
 		materials.linked_account = SSeconomy.get_dep_account(ACCOUNT_CAR)

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		/datum/material/bluespace,
 		/datum/material/plastic,
 		)
-	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container, materials_list, INFINITY, MATCONTAINER_NO_INSERT, allowed_items=/obj/item/stack, ore_silo=TRUE)
+	var/datum/component/material_container/materials = AddComponent(/datum/component/material_container, materials_list, INFINITY, MATCONTAINER_NO_INSERT, allowed_items=/obj/item/stack)
 	if (!GLOB.ore_silo_default && mapload && is_station_level(z))
 		GLOB.ore_silo_default = src
 		materials.linked_account = SSeconomy.get_dep_account(ACCOUNT_CAR)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -107,6 +107,18 @@
 	if(HAS_TRAIT_NOT_FROM(src, TRAIT_CHUNKYFINGERS, RIGHT_ARM_TRAIT) && HAS_TRAIT_NOT_FROM(src, TRAIT_CHUNKYFINGERS, LEFT_ARM_TRAIT))
 		return TRUE
 	return (active_hand_index % 2) ? HAS_TRAIT_FROM(src, TRAIT_CHUNKYFINGERS, LEFT_ARM_TRAIT) : HAS_TRAIT_FROM(src, TRAIT_CHUNKYFINGERS, RIGHT_ARM_TRAIT)
+
+/mob/living/carbon/human/get_bank_account(hand_first)
+	RETURN_TYPE(/datum/bank_account)
+	var/datum/bank_account/account
+	var/obj/item/card/id/I = get_idcard(hand_first)
+
+	if(I && I.registered_account)
+		account = I.registered_account
+		return account
+
+	return FALSE
+
 /mob/living/carbon/human/get_policy_keywords()
 	. = ..()
 	. += "[dna.species.type]"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -541,7 +541,7 @@
 	return held_item.GetID()
 
 //Returns the bank account of an ID the user may be holding.
-/mob/living/proc/get_bank_account()
+/mob/living/get_bank_account(hand_first)
 	RETURN_TYPE(/datum/bank_account)
 	var/datum/bank_account/account
 	var/obj/item/card/id/I = get_idcard()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -464,3 +464,6 @@
 		stack_trace("Silicon [src] ( [type] ) was somehow missing their integrated tablet. Please make a bug report.")
 		create_modularInterface()
 	modularInterface.saved_identification = newname
+
+/mob/living/silicon/get_bank_account()
+	return SSeconomy.get_dep_account(ACCOUNT_CIV)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -370,3 +370,7 @@
 
 /mob/living/simple_animal/drone/electrocute_act(shock_damage, source, siemens_coeff, flags = NONE)
 	return FALSE //So they don't die trying to fix wiring
+
+/mob/living/simple_animal/drone/get_bank_account(hand_first)
+	return SSeconomy.get_dep_account(ACCOUNT_CIV)
+

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1137,6 +1137,9 @@
 	if(client.mouse_override_icon)
 		client.mouse_pointer_icon = client.mouse_override_icon
 
+/mob/proc/get_bank_account(hand_first)
+	return
+
 /**
  * Can this mob see in the dark
  *

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -379,6 +379,6 @@
 
 /obj/machinery/rnd/production/examine(mob/user)
 	. = ..()
-	. += span_notice("Alt-click to toggle between local and remote storage.")
+
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Storing up to <b>[materials.local_size]</b> material units.<br>Material consumption at <b>[efficiency_coeff * 100]%</b>.<br>Build time reduced by <b>[100 - efficiency_coeff * 100]%</b>.")

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -319,8 +319,14 @@
 
 		borg.cell.use(SILICON_LATHE_TAX)
 
-	materials.mat_container.use_materials(efficient_mats, print_quantity)
-	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats)
+	var/datum/bank_account/user_account = usr.get_bank_account()
+	if(materials.mat_container.linked_account && !(obj_flags & EMAGGED))
+		var/cost = materials.mat_container.get_material_list_cost(efficient_mats)
+		if(!user_account.has_money(cost))
+			say("Insufficient funds to complete prototype[amount > 1? "s" : ""].")
+			return FALSE
+	materials.mat_container.use_materials(efficient_mats, print_quantity, user_account)
+	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats, !(obj_flags & EMAGGED))
 
 	for(var/reagent in design.reagents_list)
 		reagents.remove_reagent(reagent, design.reagents_list[reagent] * print_quantity * coefficient)
@@ -347,9 +353,8 @@
 	if(materials.on_hold())
 		say("Mineral access is on hold, please contact the quartermaster.")
 		return 0
-
-	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location())
-
+	var/obj/item/card/id/user_id = usr.get_idcard(TRUE)
+	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location(), user_id.registered_account)
 	var/list/matlist = list()
 	matlist[eject_sheet] = MINERAL_MATERIAL_AMOUNT
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -40,7 +40,9 @@
 		"lathe", \
 		mapload, \
 		mat_container_flags = BREAKDOWN_FLAGS_LATHE, \
+		single_storage = FALSE, \
 	)
+	/*
 	AddComponent(
 		/datum/component/payment, \
 		0, \
@@ -48,6 +50,7 @@
 		PAYMENT_CLINICAL, \
 		TRUE, \
 	)
+	*/
 
 	create_reagents(0, OPENCONTAINER)
 	if(stored_research)
@@ -190,6 +193,11 @@
 
 		if("build")
 			user_try_print_id(params["ref"], params["amount"])
+
+/obj/machinery/rnd/production/AltClick(mob/user)
+	to_chat(user, span_notice("You encabulate [src], rerouting its material intake to [materials.mat_container.ore_silo_storage ? "local" : "remote"] storage."))
+	materials.swap_storage()
+	return ..()
 
 /// Updates the fabricator's efficiency coefficient based on the installed parts.
 /obj/machinery/rnd/production/proc/calculate_efficiency()

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -149,6 +149,7 @@
 
 	data["designs"] = designs
 	data["fabName"] = name
+	data["materials"] = materials.mat_container?.ui_data()
 
 	return data
 

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -379,6 +379,6 @@
 
 /obj/machinery/rnd/production/examine(mob/user)
 	. = ..()
-
+	. += span_notice("Alt-click to toggle between local and remote storage.")
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Storing up to <b>[materials.local_size]</b> material units.<br>Material consumption at <b>[efficiency_coeff * 100]%</b>.<br>Build time reduced by <b>[100 - efficiency_coeff * 100]%</b>.")

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -40,9 +40,7 @@
 		"lathe", \
 		mapload, \
 		mat_container_flags = BREAKDOWN_FLAGS_LATHE, \
-		single_storage = FALSE, \
 	)
-	/*
 	AddComponent(
 		/datum/component/payment, \
 		0, \
@@ -50,7 +48,6 @@
 		PAYMENT_CLINICAL, \
 		TRUE, \
 	)
-	*/
 
 	create_reagents(0, OPENCONTAINER)
 	if(stored_research)
@@ -193,11 +190,6 @@
 
 		if("build")
 			user_try_print_id(params["ref"], params["amount"])
-
-/obj/machinery/rnd/production/AltClick(mob/user)
-	to_chat(user, span_notice("You encabulate [src], rerouting its material intake to [materials.mat_container.ore_silo_storage ? "local" : "remote"] storage."))
-	materials.swap_storage()
-	return ..()
 
 /// Updates the fabricator's efficiency coefficient based on the installed parts.
 /obj/machinery/rnd/production/proc/calculate_efficiency()

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -323,7 +323,7 @@
 	if(materials.mat_container.linked_account && !(obj_flags & EMAGGED))
 		var/cost = materials.mat_container.get_material_list_cost(efficient_mats)
 		if(!user_account.has_money(cost))
-			say("Insufficient funds to complete prototype[amount > 1? "s" : ""].")
+			say("Insufficient funds to complete prototype[print_quantity > 1? "s" : ""].")
 			return FALSE
 	materials.mat_container.use_materials(efficient_mats, print_quantity, user_account)
 	materials.silo_log(src, "built", -print_quantity, "[design.name]", efficient_mats, !(obj_flags & EMAGGED))
@@ -353,8 +353,8 @@
 	if(materials.on_hold())
 		say("Mineral access is on hold, please contact the quartermaster.")
 		return 0
-	var/obj/item/card/id/user_id = usr.get_idcard(TRUE)
-	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location(), user_id.registered_account)
+	var/datum/bank_account/user_account = usr.get_bank_account(TRUE)
+	var/count = mat_container.retrieve_sheets(text2num(eject_amt), eject_sheet, drop_location(), user_account)
 	var/list/matlist = list()
 	matlist[eject_sheet] = MINERAL_MATERIAL_AMOUNT
 

--- a/code/modules/research/machinery/circuit_imprinter.dm
+++ b/code/modules/research/machinery/circuit_imprinter.dm
@@ -21,4 +21,4 @@
 	desc = "Manufactures circuit boards for the construction of machines. Its ancient construction may limit its ability to print all known technology."
 	allowed_buildtypes = AWAY_IMPRINTER
 	circuit = /obj/item/circuitboard/machine/circuit_imprinter/offstation
-	charges_tax = FALSE
+//	charges_tax = FALSE

--- a/code/modules/research/machinery/departmental_protolathe.dm
+++ b/code/modules/research/machinery/departmental_protolathe.dm
@@ -14,7 +14,7 @@
 
 /obj/machinery/rnd/production/protolathe/department/engineering/no_tax
 	circuit = /obj/item/circuitboard/machine/protolathe/department/engineering/no_tax
-	charges_tax = FALSE
+//	charges_tax = FALSE
 
 /obj/machinery/rnd/production/protolathe/department/service
 	name = "department protolathe (Service)"

--- a/code/modules/research/machinery/protolathe.dm
+++ b/code/modules/research/machinery/protolathe.dm
@@ -23,4 +23,4 @@
 	desc = "Converts raw materials into useful objects. Its ancient construction may limit its ability to print all known technology."
 	circuit = /obj/item/circuitboard/machine/protolathe/offstation
 	allowed_buildtypes = AWAY_LATHE
-	charges_tax = FALSE
+//	charges_tax = FALSE

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -55,13 +55,7 @@
 /obj/machinery/mecha_part_fabricator/Initialize(mapload)
 	if(!CONFIG_GET(flag/no_default_techweb_link))
 		connect_techweb(SSresearch.science_tech)
-	rmat = AddComponent(
-		/datum/component/remote_materials, \
-		"mechfab", \
-		mapload, \
-		mat_container_flags = BREAKDOWN_FLAGS_LATHE, \
-		single_storage = FALSE, \
-	)
+	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init, mat_container_flags=BREAKDOWN_FLAGS_LATHE)
 	cached_designs = list()
 	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	if(stored_research)
@@ -83,10 +77,6 @@
 	if(!QDELETED(tool.buffer) && istype(tool.buffer, /datum/techweb))
 		connect_techweb(tool.buffer)
 	return TRUE
-
-/obj/machinery/mecha_part_fabricator/AltClick(mob/user)
-	to_chat(user, span_notice("You encabulate [src], rerouting its material intake to [rmat.mat_container.ore_silo_storage ? "local" : "remote"] storage."))
-	rmat.swap_storage()
 
 /obj/machinery/mecha_part_fabricator/proc/on_techweb_update()
 	SIGNAL_HANDLER

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -55,7 +55,13 @@
 /obj/machinery/mecha_part_fabricator/Initialize(mapload)
 	if(!CONFIG_GET(flag/no_default_techweb_link))
 		connect_techweb(SSresearch.science_tech)
-	rmat = AddComponent(/datum/component/remote_materials, "mechfab", mapload && link_on_init, mat_container_flags=BREAKDOWN_FLAGS_LATHE)
+	rmat = AddComponent(
+		/datum/component/remote_materials, \
+		"mechfab", \
+		mapload, \
+		mat_container_flags = BREAKDOWN_FLAGS_LATHE, \
+		single_storage = FALSE, \
+	)
 	cached_designs = list()
 	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	if(stored_research)
@@ -77,6 +83,10 @@
 	if(!QDELETED(tool.buffer) && istype(tool.buffer, /datum/techweb))
 		connect_techweb(tool.buffer)
 	return TRUE
+
+/obj/machinery/mecha_part_fabricator/AltClick(mob/user)
+	to_chat(user, span_notice("You encabulate [src], rerouting its material intake to [rmat.mat_container.ore_silo_storage ? "local" : "remote"] storage."))
+	rmat.swap_storage()
 
 /obj/machinery/mecha_part_fabricator/proc/on_techweb_update()
 	SIGNAL_HANDLER

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -391,6 +391,7 @@
 			"name" = design.name,
 			"desc" = design.get_description(),
 			"cost" = cost,
+			"crcost" = rmat.mat_container.get_material_list_cost(design.materials), // bad implementation, please replace when possible
 			"id" = design.id,
 			"categories" = design.category,
 			"icon" = "[icon_size == size32x32 ? "" : "[icon_size] "][design.id]",
@@ -405,6 +406,10 @@
 	var/list/data = list()
 
 	data["materials"] = rmat.mat_container?.ui_data()
+	data["userBalance"] = user_account.account_balance
+	data["hasLinkedAccount"] = rmat.mat_container?.linked_account != null
+	data["linkedBalance"] = rmat.mat_container?.linked_account.account_balance
+	//data["linkedCostModifier"] = materials.mat_container?.cost_modifier
 	data["queue"] = list()
 	data["processing"] = process_queue
 

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -399,6 +399,7 @@
 		)
 
 	data["designs"] = designs
+	data["materials"] = rmat.mat_container?.ui_data()
 
 	return data
 
@@ -406,6 +407,7 @@
 	var/list/data = list()
 
 	data["materials"] = rmat.mat_container?.ui_data()
+	var/datum/bank_account/user_account = user.get_bank_account()
 	data["userBalance"] = user_account.account_balance
 	data["hasLinkedAccount"] = rmat.mat_container?.linked_account != null
 	data["linkedBalance"] = rmat.mat_container?.linked_account.account_balance

--- a/tgui/packages/tgui/interfaces/ExosuitFabricator.tsx
+++ b/tgui/packages/tgui/interfaces/ExosuitFabricator.tsx
@@ -18,8 +18,11 @@ export const ExosuitFabricator = (props, context) => {
 
   const availableMaterials: MaterialMap = {};
 
+  const materialPrices: MaterialMap = {};
+
   for (const material of data.materials) {
     availableMaterials[material.name] = material.amount;
+    materialPrices[material.name] = material.value;
   }
 
   return (
@@ -33,7 +36,11 @@ export const ExosuitFabricator = (props, context) => {
                   designs={Object.values(data.designs)}
                   availableMaterials={availableMaterials}
                   buildRecipeElement={(design, availableMaterials) => (
-                    <Recipe available={availableMaterials} design={design} />
+                    <Recipe
+                      available={availableMaterials}
+                      design={design}
+                      materialPrices={materialPrices}
+                    />
                   )}
                   categoryButtons={(category) => (
                     <Button
@@ -61,7 +68,10 @@ export const ExosuitFabricator = (props, context) => {
             </Stack>
           </Stack.Item>
           <Stack.Item width="420px">
-            <Queue availableMaterials={availableMaterials} />
+            <Queue
+              availableMaterials={availableMaterials}
+              materialPrices={materialPrices}
+            />
           </Stack.Item>
         </Stack>
       </Window.Content>
@@ -69,9 +79,16 @@ export const ExosuitFabricator = (props, context) => {
   );
 };
 
-const Recipe = (props: { design: Design; available: MaterialMap }, context) => {
+const Recipe = (
+  props: {
+    design: Design;
+    available: MaterialMap;
+    materialPrices: MaterialMap;
+  },
+  context
+) => {
   const { act, data } = useBackend<ExosuitFabricatorData>(context);
-  const { design, available } = props;
+  const { design, available, materialPrices } = props;
 
   const canPrint = !Object.entries(design.cost).some(
     ([material, amount]) =>
@@ -97,6 +114,9 @@ const Recipe = (props: { design: Design; available: MaterialMap }, context) => {
             design={design}
             amount={1}
             available={available}
+            hasLinkedAccount={data.hasLinkedAccount}
+            materialPrices={materialPrices}
+            userBalance={data.userBalance}
           />
         }>
         <div
@@ -145,9 +165,12 @@ const Recipe = (props: { design: Design; available: MaterialMap }, context) => {
   );
 };
 
-const Queue = (props: { availableMaterials: MaterialMap }, context) => {
+const Queue = (
+  props: { availableMaterials: MaterialMap; materialPrices: MaterialMap },
+  context
+) => {
   const { act, data } = useBackend<ExosuitFabricatorData>(context);
-  const { availableMaterials } = props;
+  const { availableMaterials, materialPrices } = props;
   const { designs, processing } = data;
 
   const queue = data.queue || [];
@@ -200,15 +223,26 @@ const Queue = (props: { availableMaterials: MaterialMap }, context) => {
                 )}
               </>
             }>
-            <MaterialCostSequence
-              available={availableMaterials}
-              costMap={materialCosts}
-            />
+            <div>
+              <MaterialCostSequence
+                available={availableMaterials}
+                costMap={materialCosts}
+                hasLinkedAccount={data.hasLinkedAccount}
+                materialPrices={materialPrices}
+                userBalance={data.userBalance}
+              />
+              {data.hasLinkedAccount
+                ? 'Final credit cost may vary due to fluctuations in supply.'
+                : null}
+            </div>
           </Section>
         </Stack.Item>
         <Stack.Item grow>
           <Section fill style={{ 'overflow': 'auto' }}>
-            <QueueList availableMaterials={availableMaterials} />
+            <QueueList
+              availableMaterials={availableMaterials}
+              materialPrices={materialPrices}
+            />
           </Section>
         </Stack.Item>
       </Stack>
@@ -216,9 +250,12 @@ const Queue = (props: { availableMaterials: MaterialMap }, context) => {
   );
 };
 
-const QueueList = (props: { availableMaterials: MaterialMap }, context) => {
+const QueueList = (
+  props: { availableMaterials: MaterialMap; materialPrices: MaterialMap },
+  context
+) => {
   const { act, data } = useBackend<ExosuitFabricatorData>(context);
-  const { availableMaterials } = props;
+  const { availableMaterials, materialPrices } = props;
 
   const queue = data.queue || [];
   const designs = data.designs;
@@ -272,6 +309,9 @@ const QueueList = (props: { availableMaterials: MaterialMap }, context) => {
                   design={entry.design}
                   amount={1}
                   available={availableMaterials}
+                  hasLinkedAccount={data.hasLinkedAccount}
+                  materialPrices={materialPrices}
+                  userBalance={data.userBalance}
                 />
               }>
               <div

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
@@ -103,7 +103,12 @@ const MaterialCounter = (props: MaterialCounterProps, context) => {
             />
           </Flex.Item>
           <Flex.Item>
-            <AnimatedNumber value={material.amount} format={LABEL_FORMAT} />
+            <div>
+              <div>
+                <AnimatedNumber value={material.amount} format={LABEL_FORMAT} />
+              </div>
+              {material.value > 0 ? material.value + ' cr' : null}
+            </div>
           </Flex.Item>
         </Flex>
         {hovering && (

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
@@ -2,6 +2,7 @@ import { Flex } from '../../components';
 import { Design, MaterialMap } from './Types';
 import { MaterialIcon } from './MaterialIcon';
 import { formatSiUnit } from '../../format';
+import { BooleanLike } from 'common/react';
 
 export type MaterialCostSequenceProps = {
   /**
@@ -14,6 +15,21 @@ export type MaterialCostSequenceProps = {
    * `design`; otherwise, an empty list.
    */
   costMap?: MaterialMap;
+
+  /**
+   * The prices of each material in a map.
+   */
+  materialPrices: MaterialMap;
+
+  /**
+   * Whether or not we're paying for the materials we're using.
+   */
+  hasLinkedAccount: BooleanLike;
+
+  /**
+   * Balance of the user.
+   */
+  userBalance?: number;
 
   /**
    * A design to generate the cost map from.
@@ -51,7 +67,16 @@ export const MaterialCostSequence = (
   props: MaterialCostSequenceProps,
   context
 ) => {
-  const { design, amount, available, align, justify } = props;
+  const {
+    design,
+    amount,
+    available,
+    hasLinkedAccount,
+    userBalance,
+    materialPrices,
+    align,
+    justify,
+  } = props;
   let { costMap } = props;
 
   if (!costMap && !design) {
@@ -59,17 +84,23 @@ export const MaterialCostSequence = (
   }
 
   costMap ??= {};
+  let creditPrice = 0;
 
-  // NOTE FOR FUTURE ZETA: you could potentially put the credit cost calculations in this block
-  // since it's already iterating over all of the material costs of the design
   if (design) {
     for (const [name, value] of Object.entries(design.cost)) {
       costMap[name] = (costMap[name] || 0) + value;
     }
+    // creditPrice = design.crcost;
+  }
+
+  for (const [material, quantity] of Object.entries(costMap)) {
+    if (materialPrices) {
+      creditPrice += Math.ceil((materialPrices[material] * quantity) / 2000); // replace that magic number somehow
+    }
   }
 
   return (
-    <div>
+    <div style={{ 'text-align': 'center' }}>
       <Flex wrap justify={justify ?? 'space-around'} align={align ?? 'center'}>
         {Object.entries(costMap).map(([material, quantity]) => (
           <Flex.Item key={material} style={{ 'padding': '0.25em' }}>
@@ -97,7 +128,24 @@ export const MaterialCostSequence = (
           </Flex.Item>
         ))}
       </Flex>
-      {design.crcost + ' kromer'}
+      <div
+        style={
+          available && {
+            color: userBalance
+              ? (amount || 1) * creditPrice * 2 <= userBalance
+                ? '#fff'
+                : (amount || 1) * creditPrice <= userBalance
+                  ? '#f08f11'
+                  : '#db2828'
+              : '#db2828',
+          }
+        }>
+        {hasLinkedAccount
+          ? creditPrice > 0
+            ? creditPrice * (amount || 1) + ' cr'
+            : null
+          : null}
+      </div>
     </div>
   );
 };

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
@@ -60,6 +60,8 @@ export const MaterialCostSequence = (
 
   costMap ??= {};
 
+  // NOTE FOR FUTURE ZETA: you could potentially put the credit cost calculations in this block
+  // since it's already iterating over all of the material costs of the design
   if (design) {
     for (const [name, value] of Object.entries(design.cost)) {
       costMap[name] = (costMap[name] || 0) + value;
@@ -67,32 +69,35 @@ export const MaterialCostSequence = (
   }
 
   return (
-    <Flex wrap justify={justify ?? 'space-around'} align={align ?? 'center'}>
-      {Object.entries(costMap).map(([material, quantity]) => (
-        <Flex.Item key={material} style={{ 'padding': '0.25em' }}>
-          <Flex direction={'column'} align="center">
-            <Flex.Item>
-              <MaterialIcon
-                materialName={material}
-                amount={(amount || 1) * quantity}
-              />
-            </Flex.Item>
-            <Flex.Item
-              style={
-                available && {
-                  color:
-                    (amount || 1) * quantity * 2 <= available[material]
-                      ? '#fff'
-                      : (amount || 1) * quantity <= available[material]
-                        ? '#f08f11'
-                        : '#db2828',
-                }
-              }>
-              {formatSiUnit((amount || 1) * quantity, 0)}
-            </Flex.Item>
-          </Flex>
-        </Flex.Item>
-      ))}
-    </Flex>
+    <div>
+      <Flex wrap justify={justify ?? 'space-around'} align={align ?? 'center'}>
+        {Object.entries(costMap).map(([material, quantity]) => (
+          <Flex.Item key={material} style={{ 'padding': '0.25em' }}>
+            <Flex direction={'column'} align="center">
+              <Flex.Item>
+                <MaterialIcon
+                  materialName={material}
+                  amount={(amount || 1) * quantity}
+                />
+              </Flex.Item>
+              <Flex.Item
+                style={
+                  available && {
+                    color:
+                      (amount || 1) * quantity * 2 <= available[material]
+                        ? '#fff'
+                        : (amount || 1) * quantity <= available[material]
+                          ? '#f08f11'
+                          : '#db2828',
+                  }
+                }>
+                {formatSiUnit((amount || 1) * quantity, 0)}
+              </Flex.Item>
+            </Flex>
+          </Flex.Item>
+        ))}
+      </Flex>
+      {design.crcost + ' kromer'}
+    </div>
   );
 };

--- a/tgui/packages/tgui/interfaces/Fabrication/Types.ts
+++ b/tgui/packages/tgui/interfaces/Fabrication/Types.ts
@@ -36,6 +36,11 @@ export type Material = {
   removable: BooleanLike;
 
   /**
+   * The credit value of the material.
+   */
+  value: number;
+
+  /**
    * The color of the material.
    */
   color: string;
@@ -60,6 +65,11 @@ export type Design = {
    * fabricator's part efficiency.
    */
   cost: MaterialMap;
+
+  /**
+   * The individual credit cost to print the design. This is a temporary measure, please refactor ASAP.
+   */
+  crcost: number;
 
   /**
    * A reference to the design's design datum.
@@ -104,6 +114,21 @@ export type FabricatorData = {
    * quartermaster).
    */
   onHold: BooleanLike;
+
+  /**
+   * The balance of the user of the fabricator, in credits.
+   */
+  userBalance: number;
+
+  /**
+   * Whether or not the connected material storage has a linked account (and thus charges for usage of materials)
+   */
+  hasLinkedAccount: BooleanLike;
+
+  /**
+   * The balance of the linked account in question.
+   */
+  linkedBalance: number;
 
   /**
    * The set of designs that this fabricator can print, indexed by their ID.

--- a/tgui/packages/tgui/interfaces/Fabricator.tsx
+++ b/tgui/packages/tgui/interfaces/Fabricator.tsx
@@ -14,9 +14,15 @@ export const Fabricator = (props, context) => {
   // Reduce the material count array to a map of actually available materials.
   const availableMaterials: MaterialMap = {};
 
+  // maps material names to the prices of each material
+  const materialPrices: MaterialMap = {};
+
+  // if (data.materials) {
   for (const material of data.materials) {
     availableMaterials[material.name] = material.amount;
+    materialPrices[material.name] = material.value;
   }
+  // }
 
   return (
     <Window title={fabName} width={670} height={600}>
@@ -31,7 +37,13 @@ export const Fabricator = (props, context) => {
                 design,
                 availableMaterials,
                 onPrintDesign
-              ) => <Recipe design={design} available={availableMaterials} />}
+              ) => (
+                <Recipe
+                  design={design}
+                  available={availableMaterials}
+                  materialPrices={materialPrices}
+                />
+              )}
             />
           </Stack.Item>
           <Stack.Item>
@@ -59,11 +71,12 @@ type PrintButtonProps = {
   design: Design;
   quantity: number;
   available: MaterialMap;
+  materialPrices: MaterialMap;
 };
 
 const PrintButton = (props: PrintButtonProps, context) => {
   const { act, data } = useBackend<FabricatorData>(context);
-  const { design, quantity, available } = props;
+  const { design, quantity, available, materialPrices } = props;
 
   const canPrint = !Object.entries(design.cost).some(
     ([material, amount]) =>
@@ -77,6 +90,9 @@ const PrintButton = (props: PrintButtonProps, context) => {
           design={design}
           amount={quantity}
           available={available}
+          hasLinkedAccount={data.hasLinkedAccount}
+          materialPrices={materialPrices}
+          userBalance={data.userBalance}
         />
       }>
       <div
@@ -92,9 +108,16 @@ const PrintButton = (props: PrintButtonProps, context) => {
   );
 };
 
-const Recipe = (props: { design: Design; available: MaterialMap }, context) => {
+const Recipe = (
+  props: {
+    design: Design;
+    available: MaterialMap;
+    materialPrices: MaterialMap;
+  },
+  context
+) => {
   const { act, data } = useBackend<FabricatorData>(context);
-  const { design, available } = props;
+  const { design, available, materialPrices } = props;
 
   const canPrint = !Object.entries(design.cost).some(
     ([material, amount]) =>
@@ -119,6 +142,9 @@ const Recipe = (props: { design: Design; available: MaterialMap }, context) => {
             design={design}
             amount={1}
             available={available}
+            hasLinkedAccount={data.hasLinkedAccount}
+            materialPrices={materialPrices}
+            userBalance={data.userBalance}
           />
         }>
         <div
@@ -137,8 +163,18 @@ const Recipe = (props: { design: Design; available: MaterialMap }, context) => {
           <div className="FabricatorRecipe__Label">{design.name}</div>
         </div>
       </Tooltip>
-      <PrintButton design={design} quantity={5} available={available} />
-      <PrintButton design={design} quantity={10} available={available} />
+      <PrintButton
+        design={design}
+        quantity={5}
+        available={available}
+        materialPrices={materialPrices}
+      />
+      <PrintButton
+        design={design}
+        quantity={10}
+        available={available}
+        materialPrices={materialPrices}
+      />
     </div>
   );
 };

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.js
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.js
@@ -5,7 +5,8 @@ import { Window } from '../layouts';
 
 export const OreRedemptionMachine = (props, context) => {
   const { act, data } = useBackend(context);
-  const { unclaimedPoints, materials, alloys, diskDesigns, hasDisk } = data;
+  const { unclaimedPoints, userCash, materials, alloys, diskDesigns, hasDisk } =
+    data;
   return (
     <Window title="Ore Redemption Machine" width={440} height={550}>
       <Window.Content scrollable>
@@ -15,6 +16,12 @@ export const OreRedemptionMachine = (props, context) => {
             <br />
             Gibtonite and Slag are not accepted.
           </BlockQuote>
+          <Box>
+            <Box inline color="label" mr={1}>
+              User Credit Balance:
+            </Box>
+            {userCash}
+          </Box>
           <Box>
             <Box inline color="label" mr={1}>
               Unclaimed points:


### PR DESCRIPTION
## About The Pull Request

this is a port of https://github.com/Whitesands13/Whitesands/pull/619 

drawing materials in any fashion from the ore silo now costs credits. the rationale is [here](https://hackmd.io/@waspstation/economy#No-more-free-materials) its a cool document i promise but in short: mining's materials are squarely the property of the quartermaster (the one whom holds the cargo budget) and they get to control how they are distributed

~~in addition to the base markonomy changes and the work necessary to get the needed UI changes done, you now have the ability to toggle between remote and local storage at valid machines. at this time this behavior has not been extensively tested and is likely extremely buggy. local storage materials do not cost any credits to utilize.~~ nvm this was way too buggy. maybe when i'm better with all this

## Why It's Good For The Game

this change somewhat goes against the thesis of scoundrel; that the station works Better without strict hierarchy and that we don't need bureaucratic obstructions. Economy itself is kind of dubious on whether it should exist at all. It is my hope to implement some form of economy that will not just benefit the station as a whole, but will be Fun to exist in.

in a less abstract sense, it also provides cargo with a more enclosed source of passive income, hopefully allowing us to remove things like magical passive budget income in the future. 

## Changelog

:cl:
add: A small fee has been imposed by the Supply department on the use of all materials, which is highly configurable.
tweak: Costs for materials are disabled on red alert, so emergencies will still be covered.
/:cl:
